### PR TITLE
Add PostToolUse lint hook for TS/TSX files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,19 @@
       "Read(.env)",
       "Read(.env.*)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx)$' && npm run lint -- \"$f\"; } 2>/dev/null || true",
+            "statusMessage": "Linting..."
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- `.claude/settings.json` に `PostToolUse` フックを追加
- `Write` / `Edit` ツール実行後、`.ts` / `.tsx` ファイルに対して自動で `npm run lint` を実行
- lintエラーがあっても作業をブロックしない (`|| true`)

## Test plan

- [ ] TS/TSXファイルを編集後、スピナーに "Linting..." が表示されることを確認
- [ ] `.ts` / `.tsx` 以外のファイル編集時はlintが走らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)