### PR TITLE
fix: useAudioInput の engine を useState で管理してre-render同期を保証する

### DIFF
--- a/src/hooks/useAudioInput.test.ts
+++ b/src/hooks/useAudioInput.test.ts
@@ -221,6 +221,7 @@ describe("useAudioInput", () => {
       unmount();
       expect(mocks.engineStop).toHaveBeenCalled();
     });
+
   });
 
   // AudioEngine がモックされていることの確認（型チェック用）

--- a/src/hooks/useAudioInput.test.ts
+++ b/src/hooks/useAudioInput.test.ts
@@ -64,6 +64,11 @@ describe("useAudioInput", () => {
       const { result } = renderHook(() => useAudioInput());
       expect(result.current.availableDevices).toEqual([]);
     });
+
+    it("engine は null", () => {
+      const { result } = renderHook(() => useAudioInput());
+      expect(result.current.engine).toBeNull();
+    });
   });
 
   describe("start()", () => {
@@ -136,6 +141,14 @@ describe("useAudioInput", () => {
       });
       expect(result.current.error).toBe("Failed to access microphone");
     });
+
+    it("start() 後は engine が非 null になる（state として再レンダリングをトリガーする）", async () => {
+      const { result } = renderHook(() => useAudioInput());
+      await act(async () => {
+        await result.current.start();
+      });
+      expect(result.current.engine).not.toBeNull();
+    });
   });
 
   describe("stop()", () => {
@@ -170,6 +183,17 @@ describe("useAudioInput", () => {
         result.current.stop();
       });
       expect(mocks.engineStop).toHaveBeenCalled();
+    });
+
+    it("stop() 後は engine が null になる", async () => {
+      const { result } = renderHook(() => useAudioInput());
+      await act(async () => {
+        await result.current.start();
+      });
+      act(() => {
+        result.current.stop();
+      });
+      expect(result.current.engine).toBeNull();
     });
   });
 

--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -79,6 +79,8 @@ export function useAudioInput() {
     return () => {
       cancelAnimationFrame(levelAnimationRef.current);
       engineRef.current?.stop();
+      engineRef.current = null;
+      setEngine(null);
     };
   }, []);
 

--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -4,6 +4,7 @@ import type { AudioInputState } from "../types/audio";
 
 export function useAudioInput() {
   const engineRef = useRef<AudioEngine | null>(null);
+  const [engine, setEngine] = useState<AudioEngine | null>(null);
   const [state, setState] = useState<AudioInputState>({
     isPermissionGranted: false,
     isListening: false,
@@ -26,9 +27,10 @@ export function useAudioInput() {
   const start = useCallback(
     async (deviceId?: string) => {
       try {
-        const engine = new AudioEngine();
-        await engine.start(deviceId);
-        engineRef.current = engine;
+        const newEngine = new AudioEngine();
+        await newEngine.start(deviceId);
+        engineRef.current = newEngine;
+        setEngine(newEngine);
 
         const devices = await AudioEngine.enumerateDevices();
 
@@ -57,6 +59,7 @@ export function useAudioInput() {
     cancelAnimationFrame(levelAnimationRef.current);
     engineRef.current?.stop();
     engineRef.current = null;
+    setEngine(null);
     setState((prev) => ({
       ...prev,
       isListening: false,
@@ -81,7 +84,7 @@ export function useAudioInput() {
 
   return {
     ...state,
-    engine: engineRef.current,
+    engine,
     start,
     stop,
     switchDevice,


### PR DESCRIPTION
## Summary

- `engineRef.current` を直接返していた設計を廃止し、`engine` を `useState` で管理するように変更
- `start()` 時に `setEngine(newEngine)`、`stop()` 時に `setEngine(null)` を呼び出す
- `engineRef` は内部用（`updateLevel` コールバック・クリーンアップ）に引き続き使用
- テスト追加: `engine` が `start()` 後に非 null、`stop()` 後に null になることを検証

## Background

以前の実装では `engine: engineRef.current` を返しており、`start()` で engine が生成されても ref の変更は React の再レンダリングをトリガーしないため、`usePitchDetection` が最新の engine を受け取れない可能性があった（現状は `isListening` の state 変更で偶然動いていたが設計上脆弱）。

## Test plan

- [x] `useAudioInput` のテスト全件パス (21 tests)
- [x] 全テストスイート通過 (103 tests)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)