### PR TITLE
fix: AudioEngine.stop() の audioContext.close() を await する

### DIFF
--- a/src/hooks/useAudioInput.test.ts
+++ b/src/hooks/useAudioInput.test.ts
@@ -6,7 +6,7 @@ import { AudioEngine } from "../lib/audio/AudioEngine";
 // AudioEngine モジュールをまるごとモック化
 const mocks = vi.hoisted(() => ({
   engineStart: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-  engineStop: vi.fn(),
+  engineStop: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   engineGetInputLevel: vi.fn().mockReturnValue(0),
   engineIsActive: false,
   enumerateDevices: vi.fn<() => Promise<MediaDeviceInfo[]>>().mockResolvedValue(
@@ -157,8 +157,8 @@ describe("useAudioInput", () => {
       await act(async () => {
         await result.current.start();
       });
-      act(() => {
-        result.current.stop();
+      await act(async () => {
+        await result.current.stop();
       });
       expect(result.current.isListening).toBe(false);
     });
@@ -168,8 +168,8 @@ describe("useAudioInput", () => {
       await act(async () => {
         await result.current.start();
       });
-      act(() => {
-        result.current.stop();
+      await act(async () => {
+        await result.current.stop();
       });
       expect(result.current.inputLevel).toBe(0);
     });
@@ -179,8 +179,8 @@ describe("useAudioInput", () => {
       await act(async () => {
         await result.current.start();
       });
-      act(() => {
-        result.current.stop();
+      await act(async () => {
+        await result.current.stop();
       });
       expect(mocks.engineStop).toHaveBeenCalled();
     });
@@ -190,8 +190,8 @@ describe("useAudioInput", () => {
       await act(async () => {
         await result.current.start();
       });
-      act(() => {
-        result.current.stop();
+      await act(async () => {
+        await result.current.stop();
       });
       expect(result.current.engine).toBeNull();
     });

--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -55,9 +55,9 @@ export function useAudioInput() {
     [updateLevel],
   );
 
-  const stop = useCallback(() => {
+  const stop = useCallback(async () => {
     cancelAnimationFrame(levelAnimationRef.current);
-    engineRef.current?.stop();
+    await engineRef.current?.stop();
     engineRef.current = null;
     setEngine(null);
     setState((prev) => ({
@@ -69,7 +69,7 @@ export function useAudioInput() {
 
   const switchDevice = useCallback(
     async (deviceId: string) => {
-      stop();
+      await stop();
       await start(deviceId);
     },
     [start, stop],

--- a/src/lib/audio/AudioEngine.test.ts
+++ b/src/lib/audio/AudioEngine.test.ts
@@ -120,28 +120,28 @@ describe("AudioEngine", () => {
     it("stop() 後は isActive が false", async () => {
       const engine = new AudioEngine();
       await engine.start();
-      engine.stop();
+      await engine.stop();
       expect(engine.isActive).toBe(false);
     });
 
     it("stop() でストリームのトラックを停止する", async () => {
       const engine = new AudioEngine();
       await engine.start();
-      engine.stop();
+      await engine.stop();
       expect(mockTrackStop).toHaveBeenCalled();
     });
 
     it("stop() で AudioContext を閉じる", async () => {
       const engine = new AudioEngine();
       await engine.start();
-      engine.stop();
+      await engine.stop();
       expect(mockContextClose).toHaveBeenCalled();
     });
 
     it("stop() 後の getTimeDomainData は空を返す", async () => {
       const engine = new AudioEngine();
       await engine.start();
-      engine.stop();
+      await engine.stop();
       expect(engine.getTimeDomainData().length).toBe(0);
     });
   });

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -35,10 +35,10 @@ export class AudioEngine {
     this.sourceNode.connect(this.analyserNode);
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.stream?.getTracks().forEach((track) => track.stop());
     this.sourceNode?.disconnect();
-    this.audioContext?.close();
+    await this.audioContext?.close();
     this.stream = null;
     this.sourceNode = null;
     this.analyserNode = null;


### PR DESCRIPTION
## Summary

- `AudioEngine.stop()` を `async stop(): Promise<void>` に変更し、`audioContext.close()` を `await` するよう修正
- `useAudioInput` の `stop` コールバックを async 化し、`await engineRef.current?.stop()` に変更
- `switchDevice` で `await stop()` してから `await start()` を呼ぶよう修正
- テストの `engineStop` モックを `mockResolvedValue(undefined)` に更新、`act()` を `await act(async () => ...)` に統一

## Test plan

- [x] 全既存テスト (103件) がパス
- [x] 型チェック (`tsc -b`) + ビルド成功
- [ ] デバイス切り替え時に前の AudioContext が確実にクローズされることを実機で確認

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)