### PR TITLE
fix: AudioMeter の level 正規化を dB 変換に変更

### DIFF
--- a/src/components/audio/AudioMeter.test.tsx
+++ b/src/components/audio/AudioMeter.test.tsx
@@ -9,14 +9,14 @@ describe("AudioMeter", () => {
       expect(screen.getByText("0%")).toBeInTheDocument();
     });
 
-    it("レベルは 5 倍に正規化して表示する（0.1 → 50%）", () => {
-      render(<AudioMeter level={0.1} />);
-      expect(screen.getByText("50%")).toBeInTheDocument();
+    it("レベル 1 のとき 100% と表示する（0dB）", () => {
+      render(<AudioMeter level={1} />);
+      expect(screen.getByText("100%")).toBeInTheDocument();
     });
 
-    it("正規化後の値は 100% でキャップされる（0.5 → 100%）", () => {
-      render(<AudioMeter level={0.5} />);
-      expect(screen.getByText("100%")).toBeInTheDocument();
+    it("レベル 0.001 のとき 0% と表示する（-60dB 以下）", () => {
+      render(<AudioMeter level={0.001} />);
+      expect(screen.getByText("0%")).toBeInTheDocument();
     });
 
     it("ラベルテキスト「Input Level」を表示する", () => {
@@ -32,34 +32,37 @@ describe("AudioMeter", () => {
       expect(bar).toHaveStyle({ width: "0%" });
     });
 
-    it("level=0.1 のときバーの width は 50%", () => {
-      const { container } = render(<AudioMeter level={0.1} />);
-      const bar = container.querySelector("[style]");
-      expect(bar).toHaveStyle({ width: "50%" });
-    });
-
-    it("level=1 のときバーの width は 100%（キャップ）", () => {
+    it("level=1 のときバーの width は 100%（0dB）", () => {
       const { container } = render(<AudioMeter level={1} />);
       const bar = container.querySelector("[style]");
       expect(bar).toHaveStyle({ width: "100%" });
+    });
+
+    it("level=0.001 のときバーの width は 0%（-60dB 以下）", () => {
+      const { container } = render(<AudioMeter level={0.001} />);
+      const bar = container.querySelector("[style]");
+      expect(bar).toHaveStyle({ width: "0%" });
     });
   });
 
   describe("カラーコーディング", () => {
     it("低レベル（normalizedLevel ≤ 0.5）は emerald 色", () => {
-      const { container } = render(<AudioMeter level={0.05} />); // 0.05 * 5 = 0.25
+      // level=0.01 → -40dB → (−40+60)/60 ≈ 0.33
+      const { container } = render(<AudioMeter level={0.01} />);
       const bar = container.querySelector("[style]");
       expect(bar?.className).toContain("bg-emerald-500");
     });
 
     it("中レベル（0.5 < normalizedLevel ≤ 0.8）は yellow 色", () => {
-      const { container } = render(<AudioMeter level={0.12} />); // 0.12 * 5 = 0.6
+      // level=0.1 → -20dB → (−20+60)/60 ≈ 0.67
+      const { container } = render(<AudioMeter level={0.1} />);
       const bar = container.querySelector("[style]");
       expect(bar?.className).toContain("bg-yellow-500");
     });
 
     it("高レベル（normalizedLevel > 0.8）は red 色", () => {
-      const { container } = render(<AudioMeter level={0.2} />); // 0.2 * 5 = 1.0 > 0.8
+      // level=0.5 → ≈ -6dB → (−6+60)/60 ≈ 0.90
+      const { container } = render(<AudioMeter level={0.5} />);
       const bar = container.querySelector("[style]");
       expect(bar?.className).toContain("bg-red-500");
     });

--- a/src/components/audio/AudioMeter.tsx
+++ b/src/components/audio/AudioMeter.tsx
@@ -3,7 +3,8 @@ interface AudioMeterProps {
 }
 
 export function AudioMeter({ level }: AudioMeterProps) {
-  const normalizedLevel = Math.min(level * 5, 1);
+  const db = 20 * Math.log10(Math.max(level, 1e-6));
+  const normalizedLevel = Math.max(0, Math.min(1, (db + 60) / 60));
   const percentage = normalizedLevel * 100;
 
   const getColor = () => {


### PR DESCRIPTION
## Summary

- `level * 5` のマジックナンバーを廃止し、`20 * log10(level)` による dB 変換を導入
- -60dB〜0dB を 0〜1 に線形マッピングし、知覚に合ったメーター表示を実現
- テストも新しい正規化ロジックに合わせて更新

## Test plan

- [ ] `npm run test -- AudioMeter` で全テスト (10件) がパスすることを確認
- [ ] `npm run dev` でアプリを起動し、マイク入力時にメーターが自然に動くことを確認
- [ ] 低音量・高音量でメーターの色変化（emerald → yellow → red）を確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)