### PR TITLE
feat: lower default clarityThreshold to 0.85 and add sensitivity slid…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { AudioSetup } from "./components/audio/AudioSetup";
 import { PitchDisplay } from "./components/audio/PitchDisplay";
+import { SensitivitySlider } from "./components/audio/SensitivitySlider";
 import { useAudioInput } from "./hooks/useAudioInput";
 import { usePitchDetection } from "./hooks/usePitchDetection";
 
@@ -23,6 +24,11 @@ function App() {
           onStart={audio.start}
           onStop={audio.stop}
           onSwitchDevice={audio.switchDevice}
+        />
+
+        <SensitivitySlider
+          clarityThreshold={audio.clarityThreshold}
+          onThresholdChange={audio.setClarityThreshold}
         />
 
         {audio.isListening && <PitchDisplay pitch={pitch} />}

--- a/src/components/audio/SensitivitySlider.tsx
+++ b/src/components/audio/SensitivitySlider.tsx
@@ -1,0 +1,41 @@
+interface SensitivitySliderProps {
+  clarityThreshold: number;
+  onThresholdChange: (value: number) => void;
+}
+
+export function SensitivitySlider({
+  clarityThreshold,
+  onThresholdChange,
+}: SensitivitySliderProps) {
+  const percentage = Math.round(clarityThreshold * 100);
+
+  return (
+    <div className="bg-slate-800 rounded-xl p-6 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-200">
+          Detection Sensitivity
+        </h2>
+        <span className="text-sm text-slate-400 font-mono">
+          {percentage}%
+        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-slate-500 whitespace-nowrap">High</span>
+        <input
+          type="range"
+          min="50"
+          max="98"
+          step="1"
+          value={percentage}
+          onChange={(e) => onThresholdChange(Number(e.target.value) / 100)}
+          className="w-full h-2 rounded-full appearance-none cursor-pointer bg-slate-700 accent-emerald-500"
+        />
+        <span className="text-xs text-slate-500 whitespace-nowrap">Low</span>
+      </div>
+      <p className="text-xs text-slate-500">
+        Lower values detect more notes but may include false positives. Default:
+        85%
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -15,6 +15,7 @@ export function useAudioInput() {
   });
 
   const levelAnimationRef = useRef<number>(0);
+  const [clarityThreshold, setClarityThresholdState] = useState(0.85);
 
   const updateLevel = useCallback(() => {
     if (engineRef.current?.isActive) {
@@ -84,9 +85,18 @@ export function useAudioInput() {
     };
   }, []);
 
+  const setClarityThreshold = useCallback((value: number) => {
+    setClarityThresholdState(value);
+    if (engineRef.current) {
+      engineRef.current.clarityThreshold = value;
+    }
+  }, []);
+
   return {
     ...state,
     engine,
+    clarityThreshold,
+    setClarityThreshold,
     start,
     stop,
     switchDevice,

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -12,6 +12,14 @@ export class AudioEngine {
     return this.audioContext?.sampleRate ?? 48000;
   }
 
+  get clarityThreshold(): number {
+    return this.pitchAnalyzer.clarityThreshold;
+  }
+
+  set clarityThreshold(value: number) {
+    this.pitchAnalyzer.clarityThreshold = value;
+  }
+
   get isActive(): boolean {
     return this.audioContext !== null && this.audioContext.state === "running";
   }

--- a/src/lib/audio/pitchDetection.ts
+++ b/src/lib/audio/pitchDetection.ts
@@ -9,7 +9,7 @@ export class PitchAnalyzer {
   private detector: PitchDetector<Float32Array> | null = null;
   private detectorInputLength = 0;
 
-  clarityThreshold = 0.9;
+  clarityThreshold = 0.85;
 
   detectPitch(buffer: Float32Array, sampleRate: number): PitchResult {
     const now = Date.now();


### PR DESCRIPTION
…er UI

- Change PitchAnalyzer.clarityThreshold default from 0.9 to 0.85 to improve pitch detection for bass low register (E1 ≈ 41Hz)
- Add SensitivitySlider component allowing users to adjust clarity threshold from 50% to 98% via a range slider
- Expose clarityThreshold getter/setter on AudioEngine
- Wire threshold state through useAudioInput hook to App

Closes #3