### PR TITLE
fix: AudioSetup の select に selectedDeviceId を value として設定する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ function App() {
           isPermissionGranted={audio.isPermissionGranted}
           inputLevel={audio.inputLevel}
           availableDevices={audio.availableDevices}
+          selectedDeviceId={audio.selectedDeviceId}
           error={audio.error}
           onStart={audio.start}
           onStop={audio.stop}

--- a/src/components/audio/AudioSetup.test.tsx
+++ b/src/components/audio/AudioSetup.test.tsx
@@ -17,6 +17,7 @@ const defaultProps = {
   isPermissionGranted: false,
   inputLevel: 0,
   availableDevices: [],
+  selectedDeviceId: null,
   error: null,
   onStart: vi.fn(),
   onStop: vi.fn(),
@@ -139,6 +140,18 @@ describe("AudioSetup", () => {
         />,
       );
       expect(screen.getByText("Audio Input abcdefgh")).toBeInTheDocument();
+    });
+
+    it("selectedDeviceId がセレクタの value に反映される", () => {
+      render(
+        <AudioSetup
+          {...defaultProps}
+          isPermissionGranted
+          availableDevices={devices}
+          selectedDeviceId="mic2"
+        />,
+      );
+      expect(screen.getByRole("combobox")).toHaveValue("mic2");
     });
 
     it("セレクタ変更で onSwitchDevice(deviceId) が呼ばれる", () => {

--- a/src/components/audio/AudioSetup.tsx
+++ b/src/components/audio/AudioSetup.tsx
@@ -5,6 +5,7 @@ interface AudioSetupProps {
   isPermissionGranted: boolean;
   inputLevel: number;
   availableDevices: MediaDeviceInfo[];
+  selectedDeviceId: string | null;
   error: string | null;
   onStart: (deviceId?: string) => void;
   onStop: () => void;
@@ -16,6 +17,7 @@ export function AudioSetup({
   isPermissionGranted,
   inputLevel,
   availableDevices,
+  selectedDeviceId,
   error,
   onStart,
   onStop,
@@ -50,6 +52,7 @@ export function AudioSetup({
 
         {isPermissionGranted && availableDevices.length > 0 && (
           <select
+            value={selectedDeviceId ?? ""}
             onChange={(e) => onSwitchDevice(e.target.value)}
             className="bg-slate-700 text-slate-200 rounded-lg px-3 py-2 text-sm border border-slate-600 flex-1"
           >


### PR DESCRIPTION
## Summary

- `AudioSetupProps` に `selectedDeviceId: string | null` を追加
- `<select>` に `value={selectedDeviceId ?? ""}` を設定し制御コンポーネント化
- `App.tsx` で `audio.selectedDeviceId` を渡すよう更新

## Test plan

- [ ] `selectedDeviceId がセレクタの value に反映される` テストを追加・通過確認
- [ ] 既存17テストすべて通過
- [ ] `npm run build` 型エラーなし

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)