### PR TITLE
fix: fftSize を 4096 → 8192 に変更してベースの低音検出精度を改善

### DIFF
--- a/.claude/rules/audio-lib.md
+++ b/.claude/rules/audio-lib.md
@@ -10,5 +10,5 @@ paths:
 - Audio constraints must disable echoCancellation, noiseSuppression, autoGainControl for accurate pitch detection
 - PitchAnalyzer clarity threshold default: 0.9 (bass needs high confidence to avoid harmonics)
 - Bass frequency range: 30-500 Hz (low B0 to ~B4)
-- FFT size: 4096 for sufficient low-frequency resolution
+- FFT size: 8192 for improved low-frequency resolution (E1 ≈ 41Hz detection)
 - Detector instances should be reused (recreate only when buffer length changes)

--- a/src/lib/audio/AudioEngine.test.ts
+++ b/src/lib/audio/AudioEngine.test.ts
@@ -109,10 +109,10 @@ describe("AudioEngine", () => {
       expect(engine.sampleRate).toBe(44100);
     });
 
-    it("AnalyserNode の fftSize を 4096 に設定する", async () => {
+    it("AnalyserNode の fftSize を 8192 に設定する", async () => {
       const engine = new AudioEngine();
       await engine.start();
-      expect(mockAnalyser.fftSize).toBe(4096);
+      expect(mockAnalyser.fftSize).toBe(8192);
     });
   });
 

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -37,7 +37,7 @@ export class AudioEngine {
     this.stream = await navigator.mediaDevices.getUserMedia(constraints);
     this.audioContext = new AudioContext();
     this.analyserNode = this.audioContext.createAnalyser();
-    this.analyserNode.fftSize = 4096;
+    this.analyserNode.fftSize = 8192;
 
     this.sourceNode = this.audioContext.createMediaStreamSource(this.stream);
     this.sourceNode.connect(this.analyserNode);


### PR DESCRIPTION
## Summary

- `AudioEngine` の `analyserNode.fftSize` を 4096 → 8192 に変更
- sampleRate 48kHz 時の周波数分解能が ≈ 11.7Hz → ≈ 5.9Hz に改善され、E1 (≈ 41Hz) などの低音検出精度が向上
- テストおよびルールファイルも合わせて更新

Closes #8

## Test plan

- [ ] `npm test` が全件パスすること
- [ ] 実機でベース E1〜E2 あたりの検出が安定することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)