### PR TITLE
perf: getTimeDomainData() でバッファを再利用し GC 圧を低減 (fixes #10)

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -7,6 +7,7 @@ export class AudioEngine {
   private sourceNode: MediaStreamAudioSourceNode | null = null;
   private stream: MediaStream | null = null;
   private pitchAnalyzer = new PitchAnalyzer();
+  private timeDomainBuffer: Float32Array<ArrayBuffer> | null = null;
 
   get sampleRate(): number {
     return this.audioContext?.sampleRate ?? 48000;
@@ -51,15 +52,16 @@ export class AudioEngine {
     this.sourceNode = null;
     this.analyserNode = null;
     this.audioContext = null;
+    this.timeDomainBuffer = null;
   }
 
   getTimeDomainData(): Float32Array {
-    if (!this.analyserNode) {
-      return new Float32Array(0);
+    if (!this.analyserNode) return new Float32Array(0);
+    if (!this.timeDomainBuffer || this.timeDomainBuffer.length !== this.analyserNode.fftSize) {
+      this.timeDomainBuffer = new Float32Array(this.analyserNode.fftSize);
     }
-    const buffer = new Float32Array(this.analyserNode.fftSize);
-    this.analyserNode.getFloatTimeDomainData(buffer);
-    return buffer;
+    this.analyserNode.getFloatTimeDomainData(this.timeDomainBuffer);
+    return this.timeDomainBuffer;
   }
 
   getInputLevel(): number {


### PR DESCRIPTION
## Summary

- `getTimeDomainData()` が毎フレーム `new Float32Array(fftSize)` していた問題を修正
- バッファをインスタンス変数 `timeDomainBuffer` として保持し再利用
- fftSize が変わった場合のみ再確保（通常は発生しない）
- `stop()` 時に `timeDomainBuffer = null` してリークを防止

## 効果

60fps × 8192 * 4 bytes = 約 1 MB/s のアロケーションが排除され、GC 頻度が下がる。

## Test plan

- [ ] `npm run build` が通ること
- [ ] デバイス選択 → 開始 → ピッチ検出が正常に動作すること
- [ ] 停止 → 再開を繰り返しても問題ないこと

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)