### PR TITLE
refactor: useAudioInput の返り値を useMemo で安定化する

### DIFF
--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { AudioEngine } from "../lib/audio/AudioEngine";
 import type { AudioInputState } from "../types/audio";
 
@@ -92,7 +92,7 @@ export function useAudioInput() {
     }
   }, []);
 
-  return {
+  return useMemo(() => ({
     ...state,
     engine,
     clarityThreshold,
@@ -100,5 +100,5 @@ export function useAudioInput() {
     start,
     stop,
     switchDevice,
-  };
+  }), [state, engine, clarityThreshold, setClarityThreshold, start, stop, switchDevice]);
 }


### PR DESCRIPTION
## 概要

`useAudioInput` の返り値オブジェクトを `useMemo` でメモ化し、毎レンダーでの不要なオブジェクト再生成を防止する。

## 変更内容

- `useMemo` を import に追加
- 返り値オブジェクトを `useMemo` でラップ（依存配列に全プロパティを指定）
- `useMetronome` で既に適用済みの同パターンを踏襲

## 動機

CLAUDE.md に記載の教訓：
> hook内の各関数が `useCallback` で安定していても、返り値のオブジェクトリテラル自体は毎レンダーで新規生成される。依存配列にオブジェクトごと入れるとeffectが毎回再実行される

## テスト

- `npm run build` ✅ (tsc + vite build)
- `npx vitest run` ✅ (全160テストパス)

Closes #23