### PR TITLE
refactor: useTabPractice の返り値メモ化と computeStats の useMemo 化

### DIFF
--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import type { TabPreset, TimingEvent, TabSessionPhase } from "../types/practice";
 import type { AudioEngine } from "../lib/audio/AudioEngine";
 import { OnsetDetector } from "../lib/audio/onsetDetector";
@@ -172,19 +172,29 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
     };
   }, []);
 
-  return {
-    phase,
-    currentBeat,
-    loop,
-    timingEvents,
-    lastEvent,
-    stats: computeStats(timingEvents),
-    metronome: {
+  const stats = useMemo(() => computeStats(timingEvents), [timingEvents]);
+
+  const metronomeSlice = useMemo(
+    () => ({
       bpm: metronome.bpm,
       setBpm: metronome.setBpm,
       isPlaying: metronome.isPlaying,
-    },
-    startSession,
-    stopSession,
-  };
+    }),
+    [metronome.bpm, metronome.setBpm, metronome.isPlaying],
+  );
+
+  return useMemo(
+    () => ({
+      phase,
+      currentBeat,
+      loop,
+      timingEvents,
+      lastEvent,
+      stats,
+      metronome: metronomeSlice,
+      startSession,
+      stopSession,
+    }),
+    [phase, currentBeat, loop, timingEvents, lastEvent, stats, metronomeSlice, startSession, stopSession],
+  );
 }


### PR DESCRIPTION
## 概要

Issue #24 の対応。`useTabPractice` の返り値オブジェクトが毎レンダーで新規生成される問題と、`computeStats` が不要に再計算される問題を修正。

## 変更内容

1. **`computeStats` を `useMemo` で包む** — `timingEvents` が変化しない限り再計算しない
2. **`metronome` スライスオブジェクトを `useMemo` で安定化** — `bpm`, `setBpm`, `isPlaying` の個別プロパティを依存配列に指定
3. **返り値全体を `useMemo` で包む** — 消費側が安定した参照を受け取れるようになった

## 検証

- ✅ ビルド (`tsc -b` + `vite build`) 成功
- ✅ ESLint クリーン
- ✅ 全160テスト通過

Closes #24