### PR TITLE
refactor: TimingEvent を discriminated union に変更する (fixes #25)

### DIFF
--- a/src/components/practice/TimingFeedback.tsx
+++ b/src/components/practice/TimingFeedback.tsx
@@ -46,7 +46,7 @@ export function TimingFeedback({
               >
                 {judgmentLabels[lastEvent.judgment]}
               </div>
-              {lastEvent.deltaMs !== 0 && (
+              {lastEvent.judgment !== "miss" && lastEvent.deltaMs !== 0 && (
                 <div className="text-sm text-slate-400 mt-1">
                   {lastEvent.deltaMs > 0 ? "+" : ""}
                   {lastEvent.deltaMs}ms
@@ -65,7 +65,7 @@ export function TimingFeedback({
                         : "bg-orange-400"
                   }`}
                   style={{
-                    left: `${50 + (lastEvent.deltaMs / 100) * 40}%`,
+                    left: `${50 + ((lastEvent.judgment !== "miss" ? lastEvent.deltaMs : 0) / 100) * 40}%`,
                     transform: "translateX(-50%)",
                   }}
                 />

--- a/src/lib/practice/timingEvaluator.test.ts
+++ b/src/lib/practice/timingEvaluator.test.ts
@@ -124,6 +124,7 @@ describe("generateMisses", () => {
     expect(misses[0].targetBeat).toBe(1);
     expect(misses[0].judgment).toBe("miss");
     expect(misses[0].onsetTimeMs).toBeNull();
+    expect(misses[0].deltaMs).toBeNull();
     expect(misses[1].targetBeat).toBe(3);
   });
 
@@ -136,10 +137,10 @@ describe("generateMisses", () => {
 
 describe("computeStats", () => {
   it("computes hit rate and avg absolute delta", () => {
-    const events = [
+    const events: import("../../types/practice").TimingEvent[] = [
       { targetBeat: 0, targetTimeMs: 0, onsetTimeMs: 10, deltaMs: 10, judgment: "hit" as const },
       { targetBeat: 1, targetTimeMs: 500, onsetTimeMs: 460, deltaMs: -40, judgment: "early" as const },
-      { targetBeat: 2, targetTimeMs: 1000, onsetTimeMs: null, deltaMs: 0, judgment: "miss" as const },
+      { targetBeat: 2, targetTimeMs: 1000, onsetTimeMs: null, deltaMs: null, judgment: "miss" as const },
     ];
     const stats = computeStats(events);
     expect(stats.hitRate).toBeCloseTo(2 / 3);
@@ -153,8 +154,8 @@ describe("computeStats", () => {
   });
 
   it("handles all misses", () => {
-    const events = [
-      { targetBeat: 0, targetTimeMs: 0, onsetTimeMs: null, deltaMs: 0, judgment: "miss" as const },
+    const events: import("../../types/practice").TimingEvent[] = [
+      { targetBeat: 0, targetTimeMs: 0, onsetTimeMs: null, deltaMs: null, judgment: "miss" as const },
     ];
     const stats = computeStats(events);
     expect(stats.hitRate).toBe(0);

--- a/src/lib/practice/timingEvaluator.ts
+++ b/src/lib/practice/timingEvaluator.ts
@@ -1,4 +1,4 @@
-import type { TimingEvent, TimingJudgment, TabNote } from "../../types/practice";
+import type { TimingEvent, TabNote, HitTimingEvent, MissTimingEvent } from "../../types/practice";
 
 const HIT_WINDOW_MS = 100;
 
@@ -34,7 +34,7 @@ export function evaluateOnset(
   onsetTimeMs: number,
   targets: TimingTarget[],
   alreadyHitBeats: Set<number>,
-): TimingEvent | null {
+): HitTimingEvent | null {
   let closest: TimingTarget | null = null;
   let minDelta = Infinity;
 
@@ -51,7 +51,7 @@ export function evaluateOnset(
     return null;
   }
 
-  const judgment: TimingJudgment =
+  const judgment: "hit" | "early" | "late" =
     Math.abs(minDelta) <= 30 ? "hit" : minDelta < 0 ? "early" : "late";
 
   return {
@@ -69,15 +69,15 @@ export function evaluateOnset(
 export function generateMisses(
   targets: TimingTarget[],
   hitBeats: Set<number>,
-): TimingEvent[] {
+): MissTimingEvent[] {
   return targets
     .filter((t) => !hitBeats.has(t.beat))
     .map((t) => ({
       targetBeat: t.beat,
       targetTimeMs: t.timeMs,
-      onsetTimeMs: null,
-      deltaMs: 0,
-      judgment: "miss" as TimingJudgment,
+      onsetTimeMs: null as null,
+      deltaMs: null as null,
+      judgment: "miss" as const,
     }));
 }
 
@@ -90,12 +90,10 @@ export function computeStats(events: TimingEvent[]): {
 } {
   if (events.length === 0) return { hitRate: 0, avgAbsDeltaMs: 0 };
 
-  const hits = events.filter((e) => e.judgment !== "miss");
+  const hits = events.filter((e): e is import("../../types/practice").HitTimingEvent => e.judgment !== "miss");
   const hitRate = hits.length / events.length;
 
-  const deltas = hits
-    .filter((e) => e.onsetTimeMs !== null)
-    .map((e) => Math.abs(e.deltaMs));
+  const deltas = hits.map((e) => Math.abs(e.deltaMs));
   const avgAbsDeltaMs =
     deltas.length > 0 ? deltas.reduce((a, b) => a + b, 0) / deltas.length : 0;
 

--- a/src/types/practice.ts
+++ b/src/types/practice.ts
@@ -52,13 +52,24 @@ export interface TabPreset {
 
 export type TimingJudgment = "hit" | "early" | "late" | "miss";
 
-export interface TimingEvent {
+interface TimingEventBase {
   targetBeat: number;
   targetTimeMs: number;
-  onsetTimeMs: number | null; // null for misses
-  deltaMs: number; // positive = late, negative = early
-  judgment: TimingJudgment;
 }
+
+export interface HitTimingEvent extends TimingEventBase {
+  judgment: "hit" | "early" | "late";
+  onsetTimeMs: number;
+  deltaMs: number; // positive = late, negative = early
+}
+
+export interface MissTimingEvent extends TimingEventBase {
+  judgment: "miss";
+  onsetTimeMs: null;
+  deltaMs: null;
+}
+
+export type TimingEvent = HitTimingEvent | MissTimingEvent;
 
 export type TabSessionPhase = "idle" | "countdown" | "playing" | "finished";
 


### PR DESCRIPTION
## 概要

`TimingEvent` を discriminated union に変更し、型レベルで miss と hit を区別可能にする。(fixes #25)

## 背景

従来の `TimingEvent` では miss のとき `onsetTimeMs: null, deltaMs: 0` となるが、`deltaMs: 0` は「完璧なタイミングの hit」と意味的に区別できなかった。

## 変更内容

### `src/types/practice.ts`
- `TimingEvent` を `HitTimingEvent | MissTimingEvent` の discriminated union に分割
- `HitTimingEvent`: `judgment: "hit" | "early" | "late"`, `onsetTimeMs: number`, `deltaMs: number`
- `MissTimingEvent`: `judgment: "miss"`, `onsetTimeMs: null`, `deltaMs: null`

### `src/lib/practice/timingEvaluator.ts`
- `evaluateOnset` の返り値を `HitTimingEvent | null` に厳密化
- `generateMisses` の返り値を `MissTimingEvent[]` に厳密化
- `computeStats` で型ガード付き filter により冗長な null チェックを除去

### `src/components/practice/TimingFeedback.tsx`
- `deltaMs` アクセス前に `judgment !== "miss"` でナローイング

### テスト
- miss イベントの `deltaMs` を `0` → `null` に修正
- 全160テスト通過確認済み

## 確認項目

- [x] `npx tsc -b --noEmit` 型チェック通過
- [x] `npx vitest run` 全160テスト通過
