### PR TITLE
refactor: PitchResult を discriminated union に変更する (fixes #26)

### DIFF
--- a/src/components/audio/PitchDisplay.test.tsx
+++ b/src/components/audio/PitchDisplay.test.tsx
@@ -3,8 +3,9 @@ import { render, screen } from "@testing-library/react";
 import { PitchDisplay } from "./PitchDisplay";
 import type { PitchResult } from "../../types/audio";
 
-function makePitch(overrides: Partial<PitchResult> = {}): PitchResult {
+function makePitch(overrides: Partial<PitchResult & { detected: true }> = {}): PitchResult {
   return {
+    detected: true,
     frequency: 110.0,
     clarity: 0.95,
     note: "A2",

--- a/src/components/audio/PitchDisplay.tsx
+++ b/src/components/audio/PitchDisplay.tsx
@@ -5,7 +5,7 @@ interface PitchDisplayProps {
 }
 
 export function PitchDisplay({ pitch }: PitchDisplayProps) {
-  const isActive = pitch?.note != null;
+  const isActive = pitch?.detected === true;
 
   return (
     <div className="bg-slate-800 rounded-xl p-6 space-y-4">
@@ -14,7 +14,7 @@ export function PitchDisplay({ pitch }: PitchDisplayProps) {
         <span
           className={`text-6xl font-bold font-mono ${isActive ? "text-slate-100" : "text-slate-600"}`}
         >
-          {pitch?.note ?? "---"}
+          {isActive ? pitch.note : "---"}
         </span>
       </div>
 

--- a/src/hooks/usePitchDetection.test.ts
+++ b/src/hooks/usePitchDetection.test.ts
@@ -7,8 +7,9 @@ import type { PitchResult } from "../types/audio";
 // RAF コールバックを手動で制御するため、テスト内でスタブを上書き
 let rafCallbacks: FrameRequestCallback[];
 
-function makePitch(overrides: Partial<PitchResult> = {}): PitchResult {
+function makePitch(overrides: Partial<PitchResult & { detected: true }> = {}): PitchResult {
   return {
+    detected: true,
     frequency: 110,
     clarity: 0.95,
     note: "A2",
@@ -21,10 +22,9 @@ function makePitch(overrides: Partial<PitchResult> = {}): PitchResult {
 
 function makeNullPitch(): PitchResult {
   return {
+    detected: false,
     frequency: 0,
     clarity: 0,
-    note: null,
-    pitchClass: null,
     cents: 0,
     timestamp: Date.now(),
   };

--- a/src/hooks/usePitchDetection.ts
+++ b/src/hooks/usePitchDetection.ts
@@ -22,11 +22,12 @@ export function usePitchDetection(
       const result = engine.detectPitch();
       const now = Date.now();
 
-      if (result.note) {
+      if (result.detected) {
         lastValidRef.current = { pitch: result, time: now };
         setPitch((prev) => {
           if (
-            prev?.note === result.note &&
+            prev?.detected &&
+            prev.note === result.note &&
             Math.abs(prev.cents - result.cents) < MIN_CENTS_CHANGE
           ) {
             return prev;

--- a/src/lib/audio/pitchDetection.test.ts
+++ b/src/lib/audio/pitchDetection.test.ts
@@ -22,59 +22,62 @@ describe("PitchAnalyzer", () => {
   });
 
   describe("空のバッファ", () => {
-    it("空バッファではノートが null のままになる", () => {
+    it("空バッファでは detected: false になる", () => {
       const result = analyzer.detectPitch(new Float32Array(0), 44100);
-      expect(result.note).toBeNull();
+      expect(result.detected).toBe(false);
       expect(result.frequency).toBe(0);
       expect(result.clarity).toBe(0);
     });
   });
 
   describe("クラリティフィルタ", () => {
-    it("クラリティが閾値を下回る場合は null を返す", () => {
+    it("クラリティが閾値を下回る場合は detected: false を返す", () => {
       mockFindPitch.mockReturnValue([440, 0.5]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).toBeNull();
+      expect(result.detected).toBe(false);
     });
 
-    it("クラリティが閾値ちょうどの場合も null を返す（未満判定）", () => {
+    it("クラリティが閾値ちょうどの場合も detected: true を返す（以上判定）", () => {
       mockFindPitch.mockReturnValue([440, 0.9]);
-      // デフォルト閾値 0.9 → clarity < 0.9 は false → note あり
+      // デフォルト閾値 0.9 → clarity < 0.9 は false → detected: true
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).not.toBeNull();
+      expect(result.detected).toBe(true);
     });
 
     it("clarityThreshold を下げると低クラリティでも検出できる", () => {
       mockFindPitch.mockReturnValue([440, 0.7]);
       analyzer.clarityThreshold = 0.6;
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).toBe("A4");
+      expect(result.detected).toBe(true);
+      if (result.detected) {
+        expect(result.note).toBe("A4");
+      }
     });
   });
 
   describe("周波数範囲フィルタ（ベース: 30–500 Hz）", () => {
-    it("下限 (30 Hz) 未満は null を返す", () => {
+    it("下限 (30 Hz) 未満は detected: false を返す", () => {
       mockFindPitch.mockReturnValue([20, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).toBeNull();
+      expect(result.detected).toBe(false);
     });
 
-    it("上限 (500 Hz) 超過は null を返す", () => {
+    it("上限 (500 Hz) 超過は detected: false を返す", () => {
       mockFindPitch.mockReturnValue([600, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).toBeNull();
+      expect(result.detected).toBe(false);
     });
 
     it("下限ちょうど (30 Hz) は検出する", () => {
       mockFindPitch.mockReturnValue([30, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).not.toBeNull();
+      expect(result.detected).toBe(true);
     });
 
     it("上限ちょうど (500 Hz) は検出する", () => {
       mockFindPitch.mockReturnValue([500, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).not.toBeNull();
+      expect(result.detected).toBe(true);
     });
   });
 
@@ -82,6 +85,8 @@ describe("PitchAnalyzer", () => {
     it("A4 (440 Hz) を正しく変換する", () => {
       mockFindPitch.mockReturnValue([440, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
+      expect(result.detected).toBe(true);
+      if (!result.detected) return;
       expect(result.note).toBe("A4");
       expect(result.pitchClass).toBe("A");
       expect(result.frequency).toBe(440);
@@ -91,7 +96,8 @@ describe("PitchAnalyzer", () => {
     it("ベースの開放弦 E1 (約 41 Hz) を検出する", () => {
       mockFindPitch.mockReturnValue([41.2, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
-      expect(result.note).not.toBeNull();
+      expect(result.detected).toBe(true);
+      if (!result.detected) return;
       expect(result.pitchClass).toBe("E");
     });
 
@@ -99,6 +105,8 @@ describe("PitchAnalyzer", () => {
       // C#4 ≈ 277.18 Hz
       mockFindPitch.mockReturnValue([277.18, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
+      expect(result.detected).toBe(true);
+      if (!result.detected) return;
       expect(result.note).toMatch(/^C#/);
       expect(result.note).not.toMatch(/^Db/);
     });
@@ -106,6 +114,8 @@ describe("PitchAnalyzer", () => {
     it("pitchClass からオクターブ番号を取り除く", () => {
       mockFindPitch.mockReturnValue([440, 0.95]);
       const result = analyzer.detectPitch(new Float32Array(4096), 44100);
+      expect(result.detected).toBe(true);
+      if (!result.detected) return;
       expect(result.pitchClass).not.toMatch(/[0-9]/);
     });
   });

--- a/src/lib/audio/pitchDetection.ts
+++ b/src/lib/audio/pitchDetection.ts
@@ -40,6 +40,7 @@ export class PitchAnalyzer {
     const pitchClass = noteName.replace(/[0-9]/g, "");
 
     return {
+      detected: true,
       frequency,
       clarity,
       note: noteName,
@@ -52,10 +53,9 @@ export class PitchAnalyzer {
 
 function nullResult(timestamp: number): PitchResult {
   return {
+    detected: false,
     frequency: 0,
     clarity: 0,
-    note: null,
-    pitchClass: null,
     cents: 0,
     timestamp,
   };

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -1,11 +1,22 @@
-export interface PitchResult {
+interface PitchDetected {
+  detected: true;
   frequency: number;
   clarity: number;
-  note: string | null;
-  pitchClass: string | null;
+  note: string;
+  pitchClass: string;
   cents: number;
   timestamp: number;
 }
+
+interface PitchNotDetected {
+  detected: false;
+  frequency: number;
+  clarity: number;
+  cents: number;
+  timestamp: number;
+}
+
+export type PitchResult = PitchDetected | PitchNotDetected;
 
 export interface AudioInputState {
   isPermissionGranted: boolean;


### PR DESCRIPTION
## 概要

`PitchResult` を discriminated union に変更し、`note`/`pitchClass` の null 状態を型レベルで表現する。

## 変更内容

- **`src/types/audio.ts`**: `PitchDetected `(`detected: true`, `note`/`pitchClass` が `string`) と `PitchNotDetected`(`detected: false`, `note`/`pitchClass` なし) の union 型を定義
- **`src/lib/audio/pitchDetection.ts`**: `detected` フィールドを追加、`nullResult` から `note`/`pitchClass` を除去
- **`src/hooks/usePitchDetection.ts`**: `result.detected` で分岐、`prev?.detected` でナローイング
- **`src/components/audio/PitchDisplay.tsx`**: `pitch?.detected === true` による型ガード
- テスト3ファイルを discriminated union に対応するよう更新

## テスト

- ✅ ビルド成功 (`tsc -b && vite build`)
- ✅ 全160テスト通過
- ✅ lint クリーン

Closes #26