### PR TITLE
refactor: AudioEngine / MetronomeEngine の内部状態を状態マシンパターンに変更する (fixes #27)

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -1,16 +1,25 @@
 import { PitchAnalyzer } from "./pitchDetection";
 import type { PitchResult } from "../../types/audio";
 
+export type AudioEngineState =
+  | { status: "idle" }
+  | {
+      status: "active";
+      audioContext: AudioContext;
+      analyserNode: AnalyserNode;
+      sourceNode: MediaStreamAudioSourceNode;
+      stream: MediaStream;
+    };
+
 export class AudioEngine {
-  private audioContext: AudioContext | null = null;
-  private analyserNode: AnalyserNode | null = null;
-  private sourceNode: MediaStreamAudioSourceNode | null = null;
-  private stream: MediaStream | null = null;
+  private state: AudioEngineState = { status: "idle" };
   private pitchAnalyzer = new PitchAnalyzer();
   private timeDomainBuffer: Float32Array<ArrayBuffer> | null = null;
 
   get sampleRate(): number {
-    return this.audioContext?.sampleRate ?? 48000;
+    return this.state.status === "active"
+      ? this.state.audioContext.sampleRate
+      : 48000;
   }
 
   get clarityThreshold(): number {
@@ -22,7 +31,10 @@ export class AudioEngine {
   }
 
   get isActive(): boolean {
-    return this.audioContext !== null && this.audioContext.state === "running";
+    return (
+      this.state.status === "active" &&
+      this.state.audioContext.state === "running"
+    );
   }
 
   async start(deviceId?: string): Promise<void> {
@@ -35,37 +47,43 @@ export class AudioEngine {
       },
     };
 
-    this.stream = await navigator.mediaDevices.getUserMedia(constraints);
-    this.audioContext = new AudioContext();
-    this.analyserNode = this.audioContext.createAnalyser();
-    this.analyserNode.fftSize = 8192;
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
+    const audioContext = new AudioContext();
+    const analyserNode = audioContext.createAnalyser();
+    analyserNode.fftSize = 8192;
 
-    this.sourceNode = this.audioContext.createMediaStreamSource(this.stream);
-    this.sourceNode.connect(this.analyserNode);
+    const sourceNode = audioContext.createMediaStreamSource(stream);
+    sourceNode.connect(analyserNode);
+
+    this.state = { status: "active", audioContext, analyserNode, sourceNode, stream };
   }
 
   async stop(): Promise<void> {
-    this.stream?.getTracks().forEach((track) => track.stop());
-    this.sourceNode?.disconnect();
-    await this.audioContext?.close();
-    this.stream = null;
-    this.sourceNode = null;
-    this.analyserNode = null;
-    this.audioContext = null;
+    if (this.state.status !== "active") return;
+
+    const { stream, sourceNode, audioContext } = this.state;
+    this.state = { status: "idle" };
     this.timeDomainBuffer = null;
+
+    stream.getTracks().forEach((track) => track.stop());
+    sourceNode.disconnect();
+    await audioContext.close();
   }
 
   getTimeDomainData(): Float32Array {
-    if (!this.analyserNode) return new Float32Array(0);
-    if (!this.timeDomainBuffer || this.timeDomainBuffer.length !== this.analyserNode.fftSize) {
-      this.timeDomainBuffer = new Float32Array(this.analyserNode.fftSize);
+    if (this.state.status !== "active") return new Float32Array(0);
+
+    const { analyserNode } = this.state;
+    if (!this.timeDomainBuffer || this.timeDomainBuffer.length !== analyserNode.fftSize) {
+      this.timeDomainBuffer = new Float32Array(analyserNode.fftSize);
     }
-    this.analyserNode.getFloatTimeDomainData(this.timeDomainBuffer);
+    analyserNode.getFloatTimeDomainData(this.timeDomainBuffer);
     return this.timeDomainBuffer;
   }
 
   getInputLevel(): number {
-    if (!this.analyserNode) return 0;
+    if (this.state.status !== "active") return 0;
+
     const data = this.getTimeDomainData();
     let sum = 0;
     for (let i = 0; i < data.length; i++) {

--- a/src/lib/audio/MetronomeEngine.ts
+++ b/src/lib/audio/MetronomeEngine.ts
@@ -19,15 +19,18 @@ function assertBeatsPerMeasure(value: number): void {
   }
 }
 
+export type MetronomeState =
+  | { status: "idle" }
+  | { status: "ready"; audioContext: AudioContext }
+  | { status: "playing"; audioContext: AudioContext; timerID: ReturnType<typeof setInterval> };
+
 export class MetronomeEngine {
-  private audioContext: AudioContext | null = null;
-  private timerID: ReturnType<typeof setInterval> | null = null;
+  private state: MetronomeState = { status: "idle" };
   private nextNoteTime = 0;
   private currentBeat = 0;
   private _bpm: number;
   private _beatsPerMeasure: number;
   private _beatUnit: number;
-  private _isPlaying = false;
   private beatCallbacks: BeatCallback[] = [];
 
   constructor(options: MetronomeOptions) {
@@ -63,11 +66,11 @@ export class MetronomeEngine {
   }
 
   get isPlaying(): boolean {
-    return this._isPlaying;
+    return this.state.status === "playing";
   }
 
   get context(): AudioContext | null {
-    return this.audioContext;
+    return this.state.status === "idle" ? null : this.state.audioContext;
   }
 
   /** Seconds per beat (quarter note equivalent) */
@@ -92,21 +95,23 @@ export class MetronomeEngine {
    * `start()` when you're ready to begin playback.
    */
   initContext(): void {
-    if (this.audioContext) return;
+    if (this.state.status !== "idle") return;
     const ctx = new AudioContext();
     // resume() returns a promise but the important thing is that the browser
     // *unlocks* the context synchronously when called inside a gesture handler.
     void ctx.resume();
-    this.audioContext = ctx;
+    this.state = { status: "ready", audioContext: ctx };
   }
 
   async start(): Promise<void> {
-    if (this._isPlaying) return;
+    if (this.state.status === "playing") return;
 
-    if (!this.audioContext) {
+    if (this.state.status === "idle") {
       this.initContext();
     }
-    const ctx = this.audioContext!;
+    // After initContext, state is guaranteed to be "ready"
+    const { audioContext: ctx } = this.state as MetronomeState & { status: "ready" };
+
     if (ctx.state === "suspended") {
       // Race against a timeout so we don't hang forever in environments
       // where the browser refuses to unlock the AudioContext.
@@ -117,53 +122,47 @@ export class MetronomeEngine {
         throw new Error("AudioContext could not be resumed. Try clicking the Start button again.");
       }
     }
-    this._isPlaying = true;
+
     this.currentBeat = 0;
     this.nextNoteTime = ctx.currentTime + 0.05; // small initial delay
 
-    this.timerID = setInterval(() => this.scheduler(), LOOKAHEAD_MS);
+    const timerID = setInterval(() => this.scheduler(), LOOKAHEAD_MS);
+    this.state = { status: "playing", audioContext: ctx, timerID };
   }
 
   async stop(): Promise<void> {
-    if (!this._isPlaying) return;
+    if (this.state.status !== "playing") return;
 
-    this._isPlaying = false;
-    if (this.timerID !== null) {
-      clearInterval(this.timerID);
-      this.timerID = null;
-    }
-    const ctx = this.audioContext;
-    this.audioContext = null;
+    const { audioContext: ctx, timerID } = this.state;
+    this.state = { status: "idle" };
     this.currentBeat = 0;
-    if (ctx && ctx.state !== "closed") {
+
+    clearInterval(timerID);
+    if (ctx.state !== "closed") {
       await ctx.close();
     }
   }
 
   /** AudioContext currentTime in ms, or null if not playing */
   getCurrentTimeMs(): number | null {
-    if (!this.audioContext) return null;
-    return this.audioContext.currentTime * 1000;
+    if (this.state.status === "idle") return null;
+    return this.state.audioContext.currentTime * 1000;
   }
 
   private scheduler(): void {
-    if (!this.audioContext || !this._isPlaying) return;
+    if (this.state.status !== "playing") return;
 
-    while (
-      this.nextNoteTime <
-      this.audioContext.currentTime + SCHEDULE_AHEAD_S
-    ) {
-      this.scheduleClick(this.nextNoteTime, this.currentBeat);
+    const { audioContext: ctx } = this.state;
+    while (this.nextNoteTime < ctx.currentTime + SCHEDULE_AHEAD_S) {
+      this.scheduleClick(ctx, this.nextNoteTime, this.currentBeat);
       this.notifyCallbacks(this.currentBeat, this.nextNoteTime);
       this.advanceBeat();
     }
   }
 
-  private scheduleClick(time: number, beat: number): void {
-    if (!this.audioContext) return;
-
-    const osc = this.audioContext.createOscillator();
-    const gain = this.audioContext.createGain();
+  private scheduleClick(ctx: AudioContext, time: number, beat: number): void {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
 
     const isAccent = beat % this._beatsPerMeasure === 0;
     osc.frequency.value = isAccent ? 1000 : 800;
@@ -174,7 +173,7 @@ export class MetronomeEngine {
     gain.gain.exponentialRampToValueAtTime(0.001, time + 0.08);
 
     osc.connect(gain);
-    gain.connect(this.audioContext.destination);
+    gain.connect(ctx.destination);
 
     osc.start(time);
     osc.stop(time + 0.08);


### PR DESCRIPTION
## 概要

AudioEngine と MetronomeEngine が複数の nullable フィールドで状態を管理していた問題を、discriminated union による状態マシンパターンに変更。

## 変更内容

### AudioEngine
- 4つの nullable フィールド (`audioContext`, `analyserNode`, `sourceNode`, `stream`) を `AudioEngineState` (discriminated union) に統合
  - `{ status: "idle" }` — リソース未割当
  - `{ status: "active"; audioContext; analyserNode; sourceNode; stream }` — 全リソースが有効
- `status` によるナローイングで `!` アサーションと `?.` チェーンを排除
- `timeDomainBuffer` は遅延初期化キャッシュのため別フィールドとして維持

### MetronomeEngine
- `audioContext` と `timerID` を `MetronomeState` (discriminated union) に統合
  - `{ status: "idle" }` — リソース未割当
  - `{ status: "ready"; audioContext }` — AudioContext 初期化済み・再生前
  - `{ status: "playing"; audioContext; timerID }` — 再生中
- `initContext()` 後の中間状態を `ready` として型安全に表現
- `scheduler` / `scheduleClick` で AudioContext を引数渡しに変更

## 確認結果
- `tsc --noEmit`: ✅ エラーなし
- `vitest run`: ✅ 全160テスト通過
- `eslint`: ✅ エラーなし
- 公開APIの変更なし（既存の hooks / components はそのまま動作）

closes #27