### PR TITLE
fix: MetronomeControls / TimingFeedback の phase 型を TabSessionPhase に変更

### DIFF
--- a/src/components/practice/MetronomeControls.tsx
+++ b/src/components/practice/MetronomeControls.tsx
@@ -1,7 +1,9 @@
+import type { TabSessionPhase } from "../../types/practice";
+
 interface MetronomeControlsProps {
   bpm: number;
   isPlaying: boolean;
-  phase: string;
+  phase: TabSessionPhase;
   onBpmChange: (bpm: number) => void;
   onStart: () => void;
   onStop: () => void;

--- a/src/components/practice/TimingFeedback.tsx
+++ b/src/components/practice/TimingFeedback.tsx
@@ -1,9 +1,9 @@
-import type { TimingEvent, TimingJudgment } from "../../types/practice";
+import type { TabSessionPhase, TimingEvent, TimingJudgment } from "../../types/practice";
 
 interface TimingFeedbackProps {
   lastEvent: TimingEvent | null;
   stats: { hitRate: number; avgAbsDeltaMs: number };
-  phase: string;
+  phase: TabSessionPhase;
   timingEvents: TimingEvent[];
   loop: number;
 }


### PR DESCRIPTION
## 概要

MetronomeControls と TimingFeedback コンポーネントの `phase` props を `string` → `TabSessionPhase` に変更。

## 変更内容

- **MetronomeControls.tsx**: `phase: string` → `phase: TabSessionPhase`
- **TimingFeedback.tsx**: `phase: string` → `phase: TabSessionPhase`

## 効果

- 条件分岐 (`phase === "idle"` 等) でタイポした場合に型エラーが発生するようになる
- exhaustiveness checking が有効になる

## 確認

- `tsc -b` 型チェック ✅
- 全160テスト パス ✅

Closes #28