### PR TITLE
refactor: useMetronome の ensureEngine から bpm 依存を除去してカスケードを防止する

### DIFF
--- a/src/hooks/useMetronome.ts
+++ b/src/hooks/useMetronome.ts
@@ -8,8 +8,11 @@ export function useMetronome(initialBpm: number, beatsPerMeasure: number, beatUn
   const [isPlaying, setIsPlaying] = useState(false);
   const [bpm, setBpmState] = useState(initialBpm);
   const bpmRef = useRef(bpm);
-  bpmRef.current = bpm;
   const externalCallbackRef = useRef<BeatCallback | null>(null);
+
+  useEffect(() => {
+    bpmRef.current = bpm;
+  }, [bpm]);
 
   /** Create a MetronomeEngine and wire up the beat callback. */
   const ensureEngine = useCallback(() => {

--- a/src/hooks/useMetronome.ts
+++ b/src/hooks/useMetronome.ts
@@ -7,20 +7,22 @@ export function useMetronome(initialBpm: number, beatsPerMeasure: number, beatUn
   const engineRef = useRef<MetronomeEngine | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [bpm, setBpmState] = useState(initialBpm);
+  const bpmRef = useRef(bpm);
+  bpmRef.current = bpm;
   const externalCallbackRef = useRef<BeatCallback | null>(null);
 
   /** Create a MetronomeEngine and wire up the beat callback. */
   const ensureEngine = useCallback(() => {
     if (engineRef.current) return engineRef.current;
 
-    const engine = new MetronomeEngine({ bpm, beatsPerMeasure, beatUnit });
+    const engine = new MetronomeEngine({ bpm: bpmRef.current, beatsPerMeasure, beatUnit });
     engine.onBeat((beat, time) => {
       externalCallbackRef.current?.(beat, time);
     });
     engineRef.current = engine;
     setBpmState(engine.bpm);
     return engine;
-  }, [bpm, beatsPerMeasure, beatUnit]);
+  }, [beatsPerMeasure, beatUnit]);
 
   /**
    * Prepare the AudioContext synchronously inside a user-gesture handler.


### PR DESCRIPTION
## 概要

`useMetronome` の `ensureEngine` が `bpm` を依存配列に含んでいたため、BPM スライダー変更のたびに `ensureEngine` → `initContext` → `start` → `useMemo` 返り値が全てカスケード再生成されていた問題を修正。

## 変更内容

- `bpmRef` を追加し、`ensureEngine` 内で `bpm` state を直接参照する代わりに `bpmRef.current` を参照するように変更
- `ensureEngine` の依存配列から `bpm` を除去 → カスケード再生成が発生しなくなる

## 影響範囲

- `src/hooks/useMetronome.ts` のみ
- 動作の変更なし（エンジン生成時の BPM 読み取り元が state → ref に変わるだけ）

## テスト

- `npm run build` ✅
- `npx vitest run` 全160テスト通過 ✅

fixes #30