### PR TITLE
feat: Material Design 3 リデザイン

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>bass-practice</title>
+    <title>Bass Practice</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,41 +1,186 @@
-import { Link, Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
+import { tabPresets } from "../data/tabPresets";
 
 export function Layout() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const params = useParams();
 
-  const navItems = [
-    { to: "/", label: "Home" },
-    { to: "/tuner", label: "Tuner" },
-  ];
+  const isPractice = location.pathname.startsWith("/practice/tab/");
+  const practicePreset = isPractice
+    ? tabPresets.find((p) => p.id === params.presetId)
+    : undefined;
+
+  const title = isPractice
+    ? (practicePreset?.name ?? "練習")
+    : location.pathname === "/tuner"
+      ? "チューナー"
+      : "Bass Practice";
+
+  const currentTab = location.pathname === "/tuner" ? "tuner" : "home";
 
   return (
-    <div className="min-h-screen bg-slate-900 text-slate-200">
-      <header className="border-b border-slate-700 px-6 py-4">
-        <div className="max-w-4xl mx-auto flex items-center justify-between">
-          <Link to="/" className="text-2xl font-bold hover:text-white transition-colors">
-            Bass Practice
-          </Link>
-          <nav className="flex gap-4">
-            {navItems.map((item) => (
-              <Link
-                key={item.to}
-                to={item.to}
-                className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                  location.pathname === item.to
-                    ? "bg-slate-700 text-white"
-                    : "text-slate-400 hover:text-slate-200"
-                }`}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-        </div>
-      </header>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "100dvh",
+        maxWidth: 480,
+        margin: "0 auto",
+        position: "relative",
+        background: "var(--md-background)",
+      }}
+    >
+      <TopAppBar
+        title={title}
+        onBack={isPractice ? () => navigate("/") : undefined}
+      />
 
-      <main className="max-w-4xl mx-auto p-6">
+      <main
+        key={location.pathname}
+        className="page-enter"
+        style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}
+      >
         <Outlet />
       </main>
+
+      {!isPractice && (
+        <BottomNav
+          current={currentTab}
+          onChange={(id) => navigate(id === "home" ? "/" : "/tuner")}
+        />
+      )}
     </div>
+  );
+}
+
+interface TopAppBarProps {
+  title: string;
+  onBack?: () => void;
+}
+
+function TopAppBar({ title, onBack }: TopAppBarProps) {
+  return (
+    <header
+      style={{
+        background: "var(--md-surface-container)",
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "0 4px",
+        height: 64,
+        flexShrink: 0,
+        boxShadow: "0 1px 0 var(--md-outline-variant)",
+      }}
+    >
+      {onBack ? (
+        <button
+          onClick={onBack}
+          aria-label="戻る"
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--md-on-surface)",
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 20,
+            flexShrink: 0,
+          }}
+        >
+          ←
+        </button>
+      ) : (
+        <div style={{ width: 12 }} />
+      )}
+      <h1
+        style={{
+          flex: 1,
+          margin: 0,
+          font: "500 22px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface)",
+          letterSpacing: 0,
+        }}
+      >
+        {title}
+      </h1>
+    </header>
+  );
+}
+
+interface BottomNavProps {
+  current: "home" | "tuner";
+  onChange: (id: "home" | "tuner") => void;
+}
+
+function BottomNav({ current, onChange }: BottomNavProps) {
+  const items: { id: "home" | "tuner"; label: string; icon: string }[] = [
+    { id: "home", label: "ホーム", icon: "⊟" },
+    { id: "tuner", label: "チューナー", icon: "♩" },
+  ];
+  return (
+    <nav
+      style={{
+        background: "var(--md-surface-container)",
+        display: "flex",
+        alignItems: "stretch",
+        borderTop: "1px solid var(--md-outline-variant)",
+        flexShrink: 0,
+        paddingBottom: "env(safe-area-inset-bottom)",
+      }}
+    >
+      {items.map((item) => {
+        const active = current === item.id;
+        return (
+          <button
+            key={item.id}
+            onClick={() => onChange(item.id)}
+            style={{
+              flex: 1,
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 4,
+              padding: "12px 0 16px",
+              color: active
+                ? "var(--md-on-secondary-container)"
+                : "var(--md-on-surface-variant)",
+              transition: "color 0.2s",
+            }}
+          >
+            <div
+              style={{
+                background: active
+                  ? "var(--md-secondary-container)"
+                  : "transparent",
+                borderRadius: 16,
+                padding: "4px 20px",
+                transition: "background 0.2s",
+                fontSize: 18,
+                lineHeight: 1,
+              }}
+            >
+              {item.icon}
+            </div>
+            <span
+              style={{
+                font: `${active ? "600" : "400"} 12px/1 Roboto, sans-serif`,
+                letterSpacing: 0.5,
+              }}
+            >
+              {item.label}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
   );
 }

--- a/src/components/audio/AudioMeter.tsx
+++ b/src/components/audio/AudioMeter.tsx
@@ -7,23 +7,26 @@ export function AudioMeter({ level }: AudioMeterProps) {
   const normalizedLevel = Math.max(0, Math.min(1, (db + 60) / 60));
   const percentage = normalizedLevel * 100;
 
-  const getColor = () => {
-    if (normalizedLevel > 0.8) return "bg-red-500";
-    if (normalizedLevel > 0.5) return "bg-yellow-500";
-    return "bg-emerald-500";
-  };
+  const colorClass =
+    normalizedLevel > 0.8
+      ? "bg-red-500"
+      : normalizedLevel > 0.5
+        ? "bg-yellow-500"
+        : "bg-emerald-500";
 
   return (
     <div className="w-full">
-      <div className="flex items-center justify-between mb-1">
-        <span className="text-sm text-slate-400">Input Level</span>
-        <span className="text-xs text-slate-500 font-mono">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs text-[var(--md-on-surface-variant)]">
+          Input Level
+        </span>
+        <span className="text-[11px] font-mono text-[var(--md-on-surface-variant)]">
           {(normalizedLevel * 100).toFixed(0)}%
         </span>
       </div>
-      <div className="w-full h-3 bg-slate-700 rounded-full overflow-hidden">
+      <div className="w-full h-1.5 rounded-full overflow-hidden bg-[var(--md-surface-container-highest)]">
         <div
-          className={`h-full rounded-full transition-all duration-75 ${getColor()}`}
+          className={`h-full rounded-full transition-all duration-75 ${colorClass}`}
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/src/components/audio/AudioSetup.tsx
+++ b/src/components/audio/AudioSetup.tsx
@@ -1,4 +1,5 @@
 import { AudioMeter } from "./AudioMeter";
+import { Card, FilledButton, OutlinedButton } from "../md3";
 
 interface AudioSetupProps {
   isListening: boolean;
@@ -24,48 +25,80 @@ export function AudioSetup({
   onSwitchDevice,
 }: AudioSetupProps) {
   return (
-    <div className="bg-slate-800 rounded-xl p-6 space-y-4">
-      <h2 className="text-lg font-semibold text-slate-200">Audio Input</h2>
+    <Card style={{ padding: 20 }}>
+      <div
+        style={{
+          font: "500 16px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface)",
+          marginBottom: 16,
+        }}
+      >
+        Audio Input
+      </div>
 
       {error && (
-        <div className="bg-red-900/50 border border-red-700 rounded-lg p-3 text-red-300 text-sm">
+        <div
+          role="alert"
+          style={{
+            background: "#ef53501a",
+            border: "1px solid #ef535066",
+            color: "#ef5350",
+            borderRadius: 8,
+            padding: "10px 14px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+            marginBottom: 16,
+          }}
+        >
           {error}
         </div>
       )}
 
-      <div className="flex items-center gap-3">
-        {!isListening ? (
-          <button
-            onClick={() => onStart()}
-            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg transition-colors font-medium"
-          >
-            Start Listening
-          </button>
-        ) : (
-          <button
-            onClick={onStop}
-            className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors font-medium"
-          >
-            Stop
-          </button>
-        )}
+      {isPermissionGranted && availableDevices.length > 0 && (
+        <select
+          value={selectedDeviceId ?? ""}
+          onChange={(e) => onSwitchDevice(e.target.value)}
+          style={{
+            width: "100%",
+            background: "var(--md-surface-container)",
+            border: "1px solid var(--md-outline-variant)",
+            borderRadius: 8,
+            padding: "12px 16px",
+            font: "400 14px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface)",
+            marginBottom: 16,
+          }}
+        >
+          {availableDevices.map((device) => (
+            <option key={device.deviceId} value={device.deviceId}>
+              {device.label || `Audio Input ${device.deviceId.slice(0, 8)}`}
+            </option>
+          ))}
+        </select>
+      )}
 
-        {isPermissionGranted && availableDevices.length > 0 && (
-          <select
-            value={selectedDeviceId ?? ""}
-            onChange={(e) => onSwitchDevice(e.target.value)}
-            className="bg-slate-700 text-slate-200 rounded-lg px-3 py-2 text-sm border border-slate-600 flex-1"
-          >
-            {availableDevices.map((device) => (
-              <option key={device.deviceId} value={device.deviceId}>
-                {device.label || `Audio Input ${device.deviceId.slice(0, 8)}`}
-              </option>
-            ))}
-          </select>
+      {isListening && (
+        <div style={{ marginBottom: 16 }}>
+          <AudioMeter level={inputLevel} />
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 12 }}>
+        {!isListening ? (
+          <FilledButton
+            label="Start Listening"
+            icon="🎤"
+            onClick={() => onStart()}
+            style={{ flex: 1, justifyContent: "center" }}
+          />
+        ) : (
+          <OutlinedButton
+            label="Stop"
+            icon="⏹"
+            onClick={onStop}
+            style={{ flex: 1, justifyContent: "center" }}
+          />
         )}
       </div>
-
-      {isListening && <AudioMeter level={inputLevel} />}
-    </div>
+    </Card>
   );
 }

--- a/src/components/audio/PitchDisplay.tsx
+++ b/src/components/audio/PitchDisplay.tsx
@@ -1,4 +1,5 @@
 import type { PitchResult } from "../../types/audio";
+import { Card } from "../md3";
 
 interface PitchDisplayProps {
   pitch: PitchResult | null;
@@ -6,65 +7,185 @@ interface PitchDisplayProps {
 
 export function PitchDisplay({ pitch }: PitchDisplayProps) {
   const isActive = pitch?.detected === true;
+  const cents = isActive ? pitch.cents : 0;
+  const abs = Math.abs(cents);
+  const color =
+    !isActive
+      ? "var(--md-on-surface-variant)"
+      : abs <= 10
+        ? "var(--md-primary)"
+        : abs <= 25
+          ? "#f9a825"
+          : "#ef5350";
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6 space-y-4">
-      {/* Note name */}
-      <div className="text-center">
-        <span
-          className={`text-6xl font-bold font-mono ${isActive ? "text-slate-100" : "text-slate-600"}`}
+    <Card
+      style={{
+        padding: "32px 24px 24px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 20,
+      }}
+    >
+      <div style={{ textAlign: "center" }}>
+        <div
+          style={{
+            font: "300 80px/1 Roboto, sans-serif",
+            color,
+            letterSpacing: -2,
+            transition: "color 0.2s",
+          }}
         >
           {isActive ? pitch.note : "---"}
-        </span>
+        </div>
+        <div
+          style={{
+            font: "400 14px/1 Roboto Mono, monospace",
+            color: "var(--md-on-surface-variant)",
+            marginTop: 8,
+          }}
+        >
+          {isActive ? `${pitch.frequency.toFixed(1)} Hz` : "—"}
+        </div>
       </div>
 
-      {/* Cents gauge */}
-      <CentsGauge cents={isActive ? pitch.cents : 0} active={isActive} />
-
-      {/* Frequency */}
-      <div className="text-center text-sm text-slate-500 font-mono">
-        {isActive ? `${pitch.frequency.toFixed(1)} Hz` : "—"}
-      </div>
-    </div>
+      <CentsGauge cents={cents} active={isActive} />
+    </Card>
   );
 }
 
 function CentsGauge({ cents, active }: { cents: number; active: boolean }) {
-  const clampedCents = Math.max(-50, Math.min(50, cents));
-  const offset = (clampedCents / 50) * 50; // percentage offset from center
-
-  const getColor = () => {
-    const absCents = Math.abs(cents);
-    if (absCents <= 10) return "bg-emerald-500";
-    if (absCents <= 25) return "bg-yellow-500";
-    return "bg-red-500";
-  };
+  const clamped = Math.max(-50, Math.min(50, cents));
+  const abs = Math.abs(cents);
+  const colorHex =
+    abs <= 10 ? "#4ecdc4" : abs <= 25 ? "#f9a825" : "#ef5350";
+  const colorClass =
+    abs <= 10 ? "bg-emerald-500" : abs <= 25 ? "bg-yellow-500" : "bg-red-500";
+  const label = abs <= 5 ? "IN TUNE" : clamped < 0 ? "FLAT" : "SHARP";
 
   return (
-    <div className="space-y-1">
-      <div className="flex justify-between text-xs text-slate-600 font-mono">
-        <span>-50</span>
-        <span>0</span>
-        <span>+50</span>
-      </div>
-      <div className="relative w-full h-4 bg-slate-700 rounded-full overflow-hidden">
-        {/* Center line */}
-        <div className="absolute left-1/2 top-0 w-px h-full bg-slate-500" />
-
-        {/* Indicator */}
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        alignItems: "center",
+      }}
+    >
+      {/* Arc gauge */}
+      <div
+        style={{
+          position: "relative",
+          width: 240,
+          height: 130,
+          overflow: "hidden",
+        }}
+      >
+        <svg
+          width="240"
+          height="130"
+          viewBox="0 0 240 130"
+          style={{ position: "absolute", top: 0, left: 0 }}
+        >
+          <path
+            d="M 20 120 A 100 100 0 0 1 220 120"
+            fill="none"
+            stroke="var(--md-surface-container-highest)"
+            strokeWidth="12"
+            strokeLinecap="round"
+          />
+          {active && (
+            <path
+              d="M 20 120 A 100 100 0 0 1 220 120"
+              fill="none"
+              stroke={colorHex + "44"}
+              strokeWidth="12"
+              strokeLinecap="round"
+            />
+          )}
+          <line
+            x1="120"
+            y1="20"
+            x2="120"
+            y2="40"
+            stroke="var(--md-outline)"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+          {[-50, -25, 0, 25, 50].map((t) => {
+            const angle = (t / 50) * 75;
+            const rad = ((90 + angle) * Math.PI) / 180;
+            const r1 = 94;
+            const r2 = 104;
+            const x1 = 120 + r1 * Math.cos(Math.PI - rad);
+            const y1 = 120 - r1 * Math.sin(Math.PI - rad);
+            const x2 = 120 + r2 * Math.cos(Math.PI - rad);
+            const y2 = 120 - r2 * Math.sin(Math.PI - rad);
+            return (
+              <line
+                key={t}
+                x1={x1}
+                y1={y1}
+                x2={x2}
+                y2={y2}
+                stroke="var(--md-outline)"
+                strokeWidth={t === 0 ? 2 : 1}
+              />
+            );
+          })}
+        </svg>
         {active && (
           <div
-            className={`absolute top-0.5 h-3 w-3 rounded-full transition-all duration-75 ${getColor()}`}
+            className={colorClass}
             style={{
-              left: `calc(50% + ${offset}% - 6px)`,
+              position: "absolute",
+              bottom: 0,
+              left: "50%",
+              width: 2,
+              height: 100,
+              transformOrigin: "bottom center",
+              transform: `translateX(-50%) rotate(${(clamped / 50) * 75}deg)`,
+              background: colorHex,
+              borderRadius: 1,
+              transition: "transform 0.15s ease-out",
             }}
           />
         )}
+        <div
+          style={{
+            position: "absolute",
+            bottom: -6,
+            left: "50%",
+            transform: "translateX(-50%)",
+            width: 12,
+            height: 12,
+            borderRadius: 6,
+            background: active ? colorHex : "var(--md-outline)",
+            transition: "background 0.15s",
+          }}
+        />
       </div>
-      <div className="text-center text-xs text-slate-500 font-mono">
-        {active
-          ? `${cents > 0 ? "+" : ""}${cents} cents`
-          : "—"}
+
+      <div
+        style={{
+          font: "500 13px/1 Roboto, sans-serif",
+          letterSpacing: 1.5,
+          color: active ? colorHex : "var(--md-on-surface-variant)",
+          textTransform: "uppercase",
+          transition: "color 0.15s",
+        }}
+      >
+        {active ? label : "—"}
+      </div>
+
+      <div
+        style={{
+          font: "400 13px/1 Roboto Mono, monospace",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        {active ? `${cents > 0 ? "+" : ""}${cents} cents` : "—"}
       </div>
     </div>
   );

--- a/src/components/audio/SensitivitySlider.tsx
+++ b/src/components/audio/SensitivitySlider.tsx
@@ -1,3 +1,5 @@
+import { Card, Md3Slider } from "../md3";
+
 interface SensitivitySliderProps {
   clarityThreshold: number;
   onThresholdChange: (value: number) => void;
@@ -10,32 +12,74 @@ export function SensitivitySlider({
   const percentage = Math.round(clarityThreshold * 100);
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6 space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-slate-200">
+    <Card style={{ padding: 20 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 16,
+        }}
+      >
+        <div
+          style={{
+            font: "500 16px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface)",
+          }}
+        >
           Detection Sensitivity
-        </h2>
-        <span className="text-sm text-slate-400 font-mono">
+        </div>
+        <span
+          style={{
+            font: "500 14px/1 Roboto Mono, monospace",
+            color: "var(--md-primary)",
+            background: "var(--md-primary-container)",
+            padding: "4px 10px",
+            borderRadius: 8,
+          }}
+        >
           {percentage}%
         </span>
       </div>
-      <div className="flex items-center gap-3">
-        <span className="text-xs text-slate-500 whitespace-nowrap">High</span>
-        <input
-          type="range"
-          min="50"
-          max="98"
-          step="1"
+
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <span
+          style={{
+            font: "400 12px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          High
+        </span>
+        <Md3Slider
+          min={50}
+          max={98}
           value={percentage}
-          onChange={(e) => onThresholdChange(Number(e.target.value) / 100)}
-          className="w-full h-2 rounded-full appearance-none cursor-pointer bg-slate-700 accent-emerald-500"
+          onChange={(v) => onThresholdChange(v / 100)}
+          ariaLabel="Detection sensitivity"
         />
-        <span className="text-xs text-slate-500 whitespace-nowrap">Low</span>
+        <span
+          style={{
+            font: "400 12px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          Low
+        </span>
       </div>
-      <p className="text-xs text-slate-500">
+
+      <p
+        style={{
+          margin: "12px 0 0",
+          font: "400 12px/1.5 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
         Lower values detect more notes but may include false positives. Default:
         85%
       </p>
-    </div>
+    </Card>
   );
 }

--- a/src/components/md3.tsx
+++ b/src/components/md3.tsx
@@ -1,0 +1,280 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface CardProps {
+  children: ReactNode;
+  style?: CSSProperties;
+  variant?: "filled" | "outlined";
+}
+
+export function Card({ children, style, variant = "filled" }: CardProps) {
+  const base: CSSProperties = {
+    borderRadius: 12,
+    overflow: "hidden",
+    background:
+      variant === "outlined"
+        ? "var(--md-surface)"
+        : "var(--md-surface-container-high)",
+    border:
+      variant === "outlined" ? "1px solid var(--md-outline-variant)" : "none",
+    ...style,
+  };
+  return <div style={base}>{children}</div>;
+}
+
+interface ButtonProps {
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  icon?: ReactNode;
+  style?: CSSProperties;
+  type?: "button" | "submit";
+  ariaLabel?: string;
+}
+
+export function FilledButton({
+  label,
+  onClick,
+  disabled,
+  icon,
+  style,
+  type = "button",
+  ariaLabel,
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      style={{
+        background: disabled
+          ? "var(--md-on-surface-variant)"
+          : "var(--md-primary)",
+        color: disabled ? "var(--md-surface)" : "var(--md-on-primary)",
+        border: "none",
+        borderRadius: 20,
+        cursor: disabled ? "not-allowed" : "pointer",
+        padding: "10px 24px",
+        font: "500 14px/1 Roboto, sans-serif",
+        letterSpacing: 0.1,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        transition: "background 0.15s, box-shadow 0.15s",
+        ...style,
+      }}
+    >
+      {icon && <span aria-hidden>{icon}</span>}
+      {label}
+    </button>
+  );
+}
+
+export function OutlinedButton({
+  label,
+  onClick,
+  disabled,
+  icon,
+  style,
+  type = "button",
+  ariaLabel,
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      style={{
+        background: "transparent",
+        color: disabled ? "var(--md-on-surface-variant)" : "var(--md-primary)",
+        border: `1px solid ${disabled ? "var(--md-outline-variant)" : "var(--md-outline)"}`,
+        borderRadius: 20,
+        cursor: disabled ? "not-allowed" : "pointer",
+        padding: "10px 24px",
+        font: "500 14px/1 Roboto, sans-serif",
+        letterSpacing: 0.1,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        transition: "background 0.15s",
+        ...style,
+      }}
+    >
+      {icon && <span aria-hidden>{icon}</span>}
+      {label}
+    </button>
+  );
+}
+
+interface TagProps {
+  label: string;
+  style?: CSSProperties;
+}
+
+export function Tag({ label, style }: TagProps) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        height: 24,
+        padding: "0 10px",
+        borderRadius: 6,
+        background: "var(--md-surface-container-highest)",
+        color: "var(--md-on-surface-variant)",
+        font: "500 11px/1 Roboto, sans-serif",
+        letterSpacing: 0.5,
+        ...style,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface AssistChipProps {
+  label: string;
+}
+
+export function AssistChip({ label }: AssistChipProps) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        height: 28,
+        padding: "0 12px",
+        borderRadius: 14,
+        background: "var(--md-surface-container-highest)",
+        color: "var(--md-on-surface)",
+        border: "1px solid var(--md-outline-variant)",
+        font: "500 12px/1 Roboto, sans-serif",
+        letterSpacing: 0.2,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface Md3SliderProps {
+  min: number;
+  max: number;
+  step?: number;
+  value: number;
+  onChange: (value: number) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+}
+
+export function Md3Slider({
+  min,
+  max,
+  step = 1,
+  value,
+  onChange,
+  disabled,
+  ariaLabel,
+}: Md3SliderProps) {
+  const pct = ((value - min) / (max - min)) * 100;
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: 32,
+        display: "flex",
+        alignItems: "center",
+      }}
+    >
+      {/* Track */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          top: "50%",
+          height: 4,
+          borderRadius: 2,
+          background: "var(--md-surface-container-highest)",
+          transform: "translateY(-50%)",
+        }}
+      />
+      {/* Active track */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: "50%",
+          height: 4,
+          width: `${pct}%`,
+          borderRadius: 2,
+          background: disabled
+            ? "var(--md-on-surface-variant)"
+            : "var(--md-primary)",
+          transform: "translateY(-50%)",
+          transition: "width 0.1s",
+        }}
+      />
+      {/* Thumb */}
+      <div
+        style={{
+          position: "absolute",
+          left: `calc(${pct}% - 10px)`,
+          top: "50%",
+          width: 20,
+          height: 20,
+          borderRadius: 10,
+          background: disabled
+            ? "var(--md-on-surface-variant)"
+            : "var(--md-primary)",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.4)",
+          transform: "translateY(-50%)",
+          pointerEvents: "none",
+          transition: "left 0.1s",
+        }}
+      />
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          opacity: 0,
+          margin: 0,
+          cursor: disabled ? "not-allowed" : "pointer",
+        }}
+      />
+    </div>
+  );
+}
+
+interface SectionLabelProps {
+  children: ReactNode;
+}
+
+export function SectionLabel({ children }: SectionLabelProps) {
+  return (
+    <div
+      style={{
+        font: "500 11px/1 Roboto, sans-serif",
+        letterSpacing: 1.5,
+        color: "var(--md-on-surface-variant)",
+        textTransform: "uppercase",
+        padding: "0 4px",
+        marginBottom: 8,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/practice/AsciiTabDisplay.tsx
+++ b/src/components/practice/AsciiTabDisplay.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { TabPreset, TabNote } from "../../types/practice";
+import { Card } from "../md3";
 
 interface AsciiTabDisplayProps {
   preset: TabPreset;
@@ -8,86 +9,250 @@ interface AsciiTabDisplayProps {
 }
 
 const STRING_LABELS = ["G", "D", "A", "E"];
+const STRING_THICKNESS = [1, 1.5, 2, 2.5];
+const BEAT_W = 48;
+const ROW_H = 52;
+const LABEL_W = 36;
+const PADDING = 16;
 
-export function AsciiTabDisplay({ preset, currentBeat, isPlaying }: AsciiTabDisplayProps) {
+export function AsciiTabDisplay({
+  preset,
+  currentBeat,
+  isPlaying,
+}: AsciiTabDisplayProps) {
   const totalBeats = preset.timeSignature.beatsPerMeasure * preset.measures;
+  const bpm = preset.timeSignature.beatsPerMeasure;
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  // Build a map: string -> beat -> fret number (memoized to avoid rebuild on every render)
   const noteMap = useMemo(() => {
     const map = new Map<number, Map<number, TabNote>>();
     for (const note of preset.notes) {
-      if (!map.has(note.string)) {
-        map.set(note.string, new Map());
-      }
+      if (!map.has(note.string)) map.set(note.string, new Map());
       map.get(note.string)!.set(note.beat, note);
     }
     return map;
   }, [preset.notes]);
 
+  useEffect(() => {
+    if (!isPlaying || currentBeat < 0 || !scrollRef.current) return;
+    const x = LABEL_W + currentBeat * BEAT_W - 80;
+    scrollRef.current.scrollTo({ left: Math.max(0, x), behavior: "smooth" });
+  }, [currentBeat, isPlaying]);
+
+  const svgW = LABEL_W + totalBeats * BEAT_W + PADDING;
+  const svgH = 4 * ROW_H + 32;
+
   return (
-    <div className="bg-slate-800 rounded-lg p-4 font-mono text-sm overflow-x-auto">
-      {[1, 2, 3, 4].map((stringNum) => {
-        const stringNotes = noteMap.get(stringNum) ?? new Map();
-        return (
-          <div key={stringNum} className="flex items-center">
-            <span className="w-6 text-slate-500 text-right mr-2">
-              {STRING_LABELS[stringNum - 1]}
-            </span>
-            <span className="text-slate-600">|</span>
-            {Array.from({ length: totalBeats }, (_, beat) => {
-              const note = stringNotes.get(beat);
-              const isCurrent = isPlaying && beat === currentBeat;
-              const hasMeasureLine =
-                beat > 0 && beat % preset.timeSignature.beatsPerMeasure === 0;
+    <Card style={{ padding: "16px 0 8px" }}>
+      <div
+        style={{
+          font: "500 11px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+          letterSpacing: 1.2,
+          textTransform: "uppercase",
+          padding: "0 16px",
+          marginBottom: 12,
+        }}
+      >
+        タブ譜
+      </div>
 
-              return (
-                <span key={beat} className="inline-flex">
-                  {hasMeasureLine && (
-                    <span className="text-slate-600">|</span>
-                  )}
-                  <span
-                    className={`w-8 text-center ${
-                      isCurrent
-                        ? "bg-cyan-900/50 text-cyan-300 font-bold rounded"
-                        : note
-                          ? "text-slate-200"
-                          : "text-slate-600"
-                    }`}
-                  >
-                    {note ? String(note.fret) : "—"}
-                  </span>
-                </span>
-              );
-            })}
-            <span className="text-slate-600">|</span>
-          </div>
-        );
-      })}
+      <div
+        ref={scrollRef}
+        style={{ overflowX: "auto", overflowY: "visible", paddingBottom: 4 }}
+      >
+        <svg
+          width={svgW}
+          height={svgH}
+          style={{ display: "block", overflow: "visible" }}
+        >
+          {Array.from({ length: totalBeats }, (_, beat) => {
+            const x = LABEL_W + beat * BEAT_W;
+            const isCurrent = isPlaying && beat === currentBeat;
+            const isDownbeat = beat % bpm === 0;
+            return (
+              <g key={beat}>
+                {isCurrent && (
+                  <rect
+                    x={x + 2}
+                    y={4}
+                    width={BEAT_W - 4}
+                    height={4 * ROW_H - 8}
+                    rx={8}
+                    fill="var(--md-primary)"
+                    opacity={0.12}
+                  />
+                )}
+                {isDownbeat && !isCurrent && (
+                  <rect
+                    x={x}
+                    y={0}
+                    width={BEAT_W}
+                    height={4 * ROW_H}
+                    fill="var(--md-on-surface)"
+                    opacity={0.025}
+                  />
+                )}
+              </g>
+            );
+          })}
 
-      {/* Beat numbers row */}
-      <div className="flex items-center mt-1">
-        <span className="w-6 mr-2" />
-        <span className="w-px" />
-        {Array.from({ length: totalBeats }, (_, beat) => {
-          const isCurrent = isPlaying && beat === currentBeat;
-          const hasMeasureLine =
-            beat > 0 && beat % preset.timeSignature.beatsPerMeasure === 0;
-          const beatInMeasure = (beat % preset.timeSignature.beatsPerMeasure) + 1;
+          {Array.from({ length: preset.measures + 1 }, (_, m) => {
+            const x = LABEL_W + m * bpm * BEAT_W;
+            return (
+              <line
+                key={m}
+                x1={x}
+                y1={8}
+                x2={x}
+                y2={4 * ROW_H - 8}
+                stroke="var(--md-outline)"
+                strokeWidth={m === 0 || m === preset.measures ? 2 : 1}
+                strokeLinecap="round"
+              />
+            );
+          })}
 
-          return (
-            <span key={beat} className="inline-flex">
-              {hasMeasureLine && <span className="w-px" />}
-              <span
-                className={`w-8 text-center text-xs ${
-                  isCurrent ? "text-cyan-400 font-bold" : "text-slate-600"
-                }`}
+          {[1, 2, 3, 4].map((stringNum, si) => {
+            const cy = si * ROW_H + ROW_H / 2;
+            const stringNotes = noteMap.get(stringNum) ?? new Map<number, TabNote>();
+            const thickness = STRING_THICKNESS[si];
+
+            return (
+              <g key={stringNum}>
+                <text
+                  x={LABEL_W - 10}
+                  y={cy + 1}
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                  fill="var(--md-primary)"
+                  fontSize={12}
+                  fontFamily="Roboto, sans-serif"
+                  fontWeight={500}
+                >
+                  {STRING_LABELS[si]}
+                </text>
+
+                {Array.from({ length: totalBeats }, (_, beat) => {
+                  const hasNote = stringNotes.has(beat);
+                  const x1 = LABEL_W + beat * BEAT_W;
+                  const x2 = x1 + BEAT_W;
+                  return hasNote ? null : (
+                    <line
+                      key={beat}
+                      x1={x1}
+                      y1={cy}
+                      x2={x2}
+                      y2={cy}
+                      stroke="var(--md-outline-variant)"
+                      strokeWidth={thickness}
+                    />
+                  );
+                })}
+
+                {Array.from({ length: totalBeats }, (_, beat) => {
+                  const note = stringNotes.get(beat);
+                  if (!note) return null;
+                  const cx = LABEL_W + beat * BEAT_W + BEAT_W / 2;
+                  const isCurrent = isPlaying && beat === currentBeat;
+                  const r = isCurrent ? 18 : 15;
+
+                  return (
+                    <g key={beat}>
+                      {isCurrent && (
+                        <circle
+                          cx={cx}
+                          cy={cy}
+                          r={22}
+                          fill="var(--md-primary)"
+                          opacity={0.18}
+                        />
+                      )}
+                      <circle
+                        cx={cx}
+                        cy={cy}
+                        r={r}
+                        fill={
+                          isCurrent
+                            ? "var(--md-primary)"
+                            : "var(--md-surface-container-highest)"
+                        }
+                        stroke={isCurrent ? "none" : "var(--md-outline)"}
+                        strokeWidth={1}
+                        style={{ transition: "r 0.1s, fill 0.1s" }}
+                      />
+                      <text
+                        x={cx}
+                        y={cy + 1}
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        fill={
+                          isCurrent
+                            ? "var(--md-on-primary)"
+                            : "var(--md-on-surface)"
+                        }
+                        fontSize={note.fret > 9 ? 10 : 13}
+                        fontFamily="Roboto Mono, monospace"
+                        fontWeight={600}
+                      >
+                        {note.fret}
+                      </text>
+                      {note.label && (
+                        <text
+                          x={cx}
+                          y={cy + r + 9}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                          fill={
+                            isCurrent
+                              ? "var(--md-primary)"
+                              : "var(--md-on-surface-variant)"
+                          }
+                          fontSize={9}
+                          fontFamily="Roboto, sans-serif"
+                          fontWeight={500}
+                          opacity={0.85}
+                        >
+                          {note.label}
+                        </text>
+                      )}
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })}
+
+          {Array.from({ length: totalBeats }, (_, beat) => {
+            const x = LABEL_W + beat * BEAT_W + BEAT_W / 2;
+            const y = 4 * ROW_H + 16;
+            const isCurrent = isPlaying && beat === currentBeat;
+            const beatInMeasure = (beat % bpm) + 1;
+            const isOne = beatInMeasure === 1;
+            return (
+              <text
+                key={beat}
+                x={x}
+                y={y}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill={
+                  isCurrent
+                    ? "var(--md-primary)"
+                    : isOne
+                      ? "var(--md-on-surface-variant)"
+                      : "var(--md-outline)"
+                }
+                fontSize={isOne ? 12 : 10}
+                fontFamily="Roboto, sans-serif"
+                fontWeight={isCurrent || isOne ? 600 : 400}
               >
                 {beatInMeasure}
-              </span>
-            </span>
-          );
-        })}
+              </text>
+            );
+          })}
+        </svg>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/components/practice/MetronomeControls.tsx
+++ b/src/components/practice/MetronomeControls.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from "react";
 import type { TabSessionPhase } from "../../types/practice";
+import { Card, FilledButton, Md3Slider, OutlinedButton } from "../md3";
 
 interface MetronomeControlsProps {
   bpm: number;
@@ -11,54 +13,150 @@ interface MetronomeControlsProps {
 
 export function MetronomeControls({
   bpm,
-  isPlaying,
   phase,
   onBpmChange,
   onStart,
   onStop,
 }: MetronomeControlsProps) {
+  const active = phase === "playing" || phase === "countdown";
+  const beatRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const interval = (60 / bpm) * 1000;
+    const tick = () => {
+      const el = beatRef.current;
+      if (!el) return;
+      el.style.transform = "scale(1.15)";
+      el.style.background = "var(--md-primary)";
+      setTimeout(() => {
+        if (!beatRef.current) return;
+        beatRef.current.style.transform = "scale(1)";
+        beatRef.current.style.background = "var(--md-primary-container)";
+      }, 80);
+    };
+    const t = setInterval(tick, interval);
+    return () => clearInterval(t);
+  }, [active, bpm]);
+
   return (
-    <div className="bg-slate-800 rounded-lg p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium text-slate-400">Metronome</h3>
-        <div className="text-2xl font-bold tabular-nums text-white">
-          {bpm} <span className="text-sm font-normal text-slate-400">BPM</span>
+    <Card style={{ padding: 20 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 20,
+        }}
+      >
+        <div
+          style={{
+            font: "500 16px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface)",
+          }}
+        >
+          メトロノーム
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            ref={beatRef}
+            style={{
+              width: 16,
+              height: 16,
+              borderRadius: 8,
+              background: active
+                ? "var(--md-primary-container)"
+                : "var(--md-surface-container-highest)",
+              transition: "background 0.05s, transform 0.05s",
+            }}
+          />
+          <span
+            style={{
+              font: "700 28px/1 Roboto, sans-serif",
+              color: "var(--md-on-surface)",
+              letterSpacing: -1,
+            }}
+            className="tabular-nums"
+          >
+            {bpm}
+          </span>
+          <span
+            style={{
+              font: "400 14px/1 Roboto, sans-serif",
+              color: "var(--md-on-surface-variant)",
+            }}
+          >
+            BPM
+          </span>
         </div>
       </div>
 
-      <input
-        type="range"
+      <Md3Slider
         min={20}
         max={300}
         value={bpm}
-        onChange={(e) => onBpmChange(Number(e.target.value))}
-        disabled={isPlaying}
-        className="w-full accent-cyan-500"
+        onChange={onBpmChange}
+        disabled={active}
+        ariaLabel="BPM"
       />
 
-      <div className="flex gap-3">
-        {phase === "idle" || phase === "finished" ? (
-          <button
-            onClick={onStart}
-            className="flex-1 px-4 py-2 bg-cyan-600 hover:bg-cyan-500 text-white font-medium rounded transition-colors"
-          >
-            {phase === "finished" ? "Restart" : "Start"}
-          </button>
-        ) : (
-          <button
-            onClick={onStop}
-            className="flex-1 px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded transition-colors"
-          >
-            Stop
-          </button>
-        )}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginTop: 4,
+          marginBottom: 20,
+        }}
+      >
+        <span
+          style={{
+            font: "400 11px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          20
+        </span>
+        <span
+          style={{
+            font: "400 11px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          300
+        </span>
       </div>
 
       {phase === "countdown" && (
-        <div className="text-center text-lg text-yellow-400 animate-pulse">
-          Get Ready...
+        <div
+          style={{
+            textAlign: "center",
+            padding: "12px 0",
+            font: "500 16px/1 Roboto, sans-serif",
+            color: "#f9a825",
+            marginBottom: 12,
+          }}
+        >
+          ♩ 準備して…
         </div>
       )}
-    </div>
+
+      <div style={{ display: "flex", gap: 12 }}>
+        {phase === "idle" || phase === "finished" ? (
+          <FilledButton
+            label={phase === "finished" ? "Restart" : "Start"}
+            icon={phase === "finished" ? "↺" : "▶"}
+            onClick={onStart}
+            style={{ flex: 1, justifyContent: "center" }}
+          />
+        ) : (
+          <OutlinedButton
+            label="Stop"
+            icon="⏹"
+            onClick={onStop}
+            style={{ flex: 1, justifyContent: "center" }}
+          />
+        )}
+      </div>
+    </Card>
   );
 }

--- a/src/components/practice/PresetCard.tsx
+++ b/src/components/practice/PresetCard.tsx
@@ -1,34 +1,125 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { TabPreset } from "../../types/practice";
+import { Tag } from "../md3";
 
 interface PresetCardProps {
   preset: TabPreset;
 }
 
+const DIFFICULTY_LABEL: Record<string, string> = {
+  "c-major-scale": "初級",
+  "blues-bassline": "中級",
+  "waltz-pattern": "中級",
+};
+
+const DIFFICULTY_COLOR: Record<string, string> = {
+  初級: "#4ecdc4",
+  中級: "#f9a825",
+  上級: "#ef5350",
+};
+
 export function PresetCard({ preset }: PresetCardProps) {
-  const beatsDisplay = `${preset.timeSignature.beatsPerMeasure}/${preset.timeSignature.beatUnit}`;
+  const [hovered, setHovered] = useState(false);
+  const diff = DIFFICULTY_LABEL[preset.id] ?? "初級";
+  const diffColor = DIFFICULTY_COLOR[diff] ?? "#4ecdc4";
 
   return (
     <Link
       to={`/practice/tab/${preset.id}`}
-      className="block p-5 bg-slate-800 rounded-lg border border-slate-700 hover:border-slate-500 transition-colors group"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        textDecoration: "none",
+        background: hovered
+          ? "var(--md-surface-container-highest)"
+          : "var(--md-surface-container-high)",
+        borderRadius: 16,
+        padding: "20px 20px 16px",
+        transition: "background 0.15s, transform 0.15s, box-shadow 0.15s",
+        transform: hovered ? "translateY(-1px)" : "none",
+        boxShadow: hovered
+          ? "0 4px 12px rgba(0,0,0,0.3)"
+          : "0 1px 3px rgba(0,0,0,0.2)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        color: "var(--md-on-surface)",
+      }}
     >
-      <div className="flex items-start justify-between mb-2">
-        <h3 className="text-lg font-semibold text-white group-hover:text-cyan-400 transition-colors">
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            font: "500 18px/1.2 Roboto, sans-serif",
+            color: hovered ? "var(--md-primary)" : "var(--md-on-surface)",
+            transition: "color 0.15s",
+          }}
+        >
           {preset.name}
         </h3>
-        <div className="flex gap-2">
-          <span className="px-2 py-0.5 bg-slate-700 rounded text-xs text-slate-300">
-            {preset.bpm} BPM
-          </span>
-          <span className="px-2 py-0.5 bg-slate-700 rounded text-xs text-slate-300">
-            {beatsDisplay}
-          </span>
-        </div>
+        <span
+          style={{
+            flexShrink: 0,
+            display: "inline-flex",
+            alignItems: "center",
+            height: 24,
+            padding: "0 10px",
+            borderRadius: 6,
+            background: diffColor + "22",
+            color: diffColor,
+            font: "500 11px/1 Roboto, sans-serif",
+            letterSpacing: 0.5,
+          }}
+        >
+          {diff}
+        </span>
       </div>
-      <p className="text-sm text-slate-400">{preset.description}</p>
-      <div className="mt-3 text-xs text-slate-500">
-        {preset.measures} measures · {preset.notes.length} notes
+
+      <p
+        style={{
+          margin: 0,
+          font: "400 14px/1.5 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        {preset.description}
+      </p>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+        <Tag label={`${preset.bpm} BPM`} />
+        <Tag
+          label={`${preset.timeSignature.beatsPerMeasure}/${preset.timeSignature.beatUnit}`}
+        />
+        <Tag label={`${preset.measures} 小節`} />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          marginTop: 4,
+        }}
+      >
+        <span
+          style={{
+            font: "500 13px/1 Roboto, sans-serif",
+            color: "var(--md-primary)",
+            letterSpacing: 0.5,
+            opacity: hovered ? 1 : 0,
+            transition: "opacity 0.15s",
+          }}
+        >
+          練習を始める →
+        </span>
       </div>
     </Link>
   );

--- a/src/components/practice/TimingFeedback.tsx
+++ b/src/components/practice/TimingFeedback.tsx
@@ -1,4 +1,9 @@
-import type { TabSessionPhase, TimingEvent, TimingJudgment } from "../../types/practice";
+import type {
+  TabSessionPhase,
+  TimingEvent,
+  TimingJudgment,
+} from "../../types/practice";
+import { Card } from "../md3";
 
 interface TimingFeedbackProps {
   lastEvent: TimingEvent | null;
@@ -8,18 +13,14 @@ interface TimingFeedbackProps {
   loop: number;
 }
 
-const judgmentColors: Record<TimingJudgment, string> = {
-  hit: "text-green-400",
-  early: "text-yellow-400",
-  late: "text-orange-400",
-  miss: "text-red-400",
-};
-
-const judgmentLabels: Record<TimingJudgment, string> = {
-  hit: "HIT",
-  early: "EARLY",
-  late: "LATE",
-  miss: "MISS",
+const JUDGMENT_CONFIG: Record<
+  TimingJudgment,
+  { label: string; color: string; bg: string }
+> = {
+  hit: { label: "HIT", color: "#4ecdc4", bg: "#4ecdc41a" },
+  early: { label: "EARLY", color: "#f9a825", bg: "#f9a8251a" },
+  late: { label: "LATE", color: "#ff7043", bg: "#ff70431a" },
+  miss: { label: "MISS", color: "#ef5350", bg: "#ef53501a" },
 };
 
 export function TimingFeedback({
@@ -29,97 +30,251 @@ export function TimingFeedback({
   timingEvents,
   loop,
 }: TimingFeedbackProps) {
+  if (phase === "idle") return null;
+
+  const cfg = lastEvent ? JUDGMENT_CONFIG[lastEvent.judgment] : null;
+  const delta =
+    lastEvent && lastEvent.judgment !== "miss" ? lastEvent.deltaMs : 0;
+
   return (
-    <div className="space-y-4">
-      {/* Live feedback */}
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       {phase === "playing" && (
-        <div className="bg-slate-800 rounded-lg p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-medium text-slate-400">Timing</h3>
-            <span className="text-xs text-slate-500">Loop {loop + 1}</span>
+        <Card style={{ padding: 20 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 16,
+            }}
+          >
+            <div
+              style={{
+                font: "500 16px/1 Roboto, sans-serif",
+                color: "var(--md-on-surface)",
+              }}
+            >
+              Timing
+            </div>
+            <span
+              style={{
+                font: "400 12px/1 Roboto, sans-serif",
+                color: "var(--md-on-surface-variant)",
+                background: "var(--md-surface-container)",
+                padding: "4px 10px",
+                borderRadius: 12,
+              }}
+            >
+              Loop {loop + 1}
+            </span>
           </div>
 
-          {lastEvent ? (
-            <div className="text-center">
+          {lastEvent && cfg ? (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 12,
+              }}
+            >
               <div
-                className={`text-3xl font-bold ${judgmentColors[lastEvent.judgment]}`}
+                style={{
+                  font: "700 36px/1 Roboto, sans-serif",
+                  letterSpacing: 2,
+                  color: cfg.color,
+                  background: cfg.bg,
+                  padding: "10px 32px",
+                  borderRadius: 16,
+                }}
               >
-                {judgmentLabels[lastEvent.judgment]}
+                {cfg.label}
               </div>
+
               {lastEvent.judgment !== "miss" && lastEvent.deltaMs !== 0 && (
-                <div className="text-sm text-slate-400 mt-1">
+                <div
+                  style={{
+                    font: "400 14px/1 Roboto Mono, monospace",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                >
                   {lastEvent.deltaMs > 0 ? "+" : ""}
                   {lastEvent.deltaMs}ms
                 </div>
               )}
 
-              {/* Timing bar visualization */}
-              <div className="mt-3 relative h-2 bg-slate-700 rounded-full overflow-hidden">
-                <div className="absolute left-1/2 w-0.5 h-full bg-white/30" />
+              <div style={{ width: "100%" }}>
                 <div
-                  className={`absolute top-0 h-full w-2 rounded-full transition-all ${
-                    lastEvent.judgment === "hit"
-                      ? "bg-green-400"
-                      : lastEvent.judgment === "early"
-                        ? "bg-yellow-400"
-                        : "bg-orange-400"
-                  }`}
                   style={{
-                    left: `${50 + ((lastEvent.judgment !== "miss" ? lastEvent.deltaMs : 0) / 100) * 40}%`,
-                    transform: "translateX(-50%)",
+                    position: "relative",
+                    height: 6,
+                    background: "var(--md-surface-container-highest)",
+                    borderRadius: 3,
+                    overflow: "hidden",
                   }}
-                />
-              </div>
-              <div className="flex justify-between text-xs text-slate-600 mt-1">
-                <span>Early</span>
-                <span>Late</span>
+                >
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: "50%",
+                      top: 0,
+                      width: 1,
+                      height: "100%",
+                      background: "var(--md-outline)",
+                    }}
+                  />
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      height: "100%",
+                      width: 8,
+                      borderRadius: 3,
+                      background: cfg.color,
+                      left: `${50 + (delta / 100) * 40}%`,
+                      transform: "translateX(-50%)",
+                      transition: "left 0.1s",
+                    }}
+                  />
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                  }}
+                >
+                  <span
+                    style={{
+                      font: "400 11px/1 Roboto, sans-serif",
+                      color: "var(--md-on-surface-variant)",
+                    }}
+                  >
+                    Early
+                  </span>
+                  <span
+                    style={{
+                      font: "400 11px/1 Roboto, sans-serif",
+                      color: "var(--md-on-surface-variant)",
+                    }}
+                  >
+                    Late
+                  </span>
+                </div>
               </div>
             </div>
           ) : (
-            <div className="text-center text-slate-500">Play a note...</div>
+            <div
+              style={{
+                textAlign: "center",
+                font: "400 15px/1 Roboto, sans-serif",
+                color: "var(--md-on-surface-variant)",
+                padding: "16px 0",
+              }}
+            >
+              Play a note...
+            </div>
           )}
-        </div>
+        </Card>
       )}
 
-      {/* Summary (shown during play and at end) */}
-      {(phase === "playing" || phase === "finished") && timingEvents.length > 0 && (
-        <div className="bg-slate-800 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-slate-400 mb-3">
-            {phase === "finished" ? "Results" : "Stats"}
-          </h3>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <div className="text-2xl font-bold text-white">
-                {Math.round(stats.hitRate * 100)}%
-              </div>
-              <div className="text-xs text-slate-400">Hit Rate</div>
+      {(phase === "playing" || phase === "finished") &&
+        timingEvents.length > 0 && (
+          <Card style={{ padding: 20 }}>
+            <div
+              style={{
+                font: "500 16px/1 Roboto, sans-serif",
+                color: "var(--md-on-surface)",
+                marginBottom: 16,
+              }}
+            >
+              {phase === "finished" ? "Results" : "Stats"}
             </div>
-            <div>
-              <div className="text-2xl font-bold text-white">
-                {stats.avgAbsDeltaMs}ms
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 16,
+                marginBottom: 16,
+              }}
+            >
+              <div
+                style={{
+                  background: "var(--md-surface-container)",
+                  borderRadius: 12,
+                  padding: 16,
+                }}
+              >
+                <div
+                  style={{
+                    font: "700 32px/1 Roboto, sans-serif",
+                    color: "var(--md-primary)",
+                  }}
+                >
+                  {Math.round(stats.hitRate * 100)}%
+                </div>
+                <div
+                  style={{
+                    font: "400 12px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                    marginTop: 4,
+                  }}
+                >
+                  Hit Rate
+                </div>
               </div>
-              <div className="text-xs text-slate-400">Avg Offset</div>
+              <div
+                style={{
+                  background: "var(--md-surface-container)",
+                  borderRadius: 12,
+                  padding: 16,
+                }}
+              >
+                <div
+                  style={{
+                    font: "700 32px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface)",
+                  }}
+                >
+                  {stats.avgAbsDeltaMs}ms
+                </div>
+                <div
+                  style={{
+                    font: "400 12px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                    marginTop: 4,
+                  }}
+                >
+                  Avg Offset
+                </div>
+              </div>
             </div>
-          </div>
-
-          {/* Event breakdown */}
-          <div className="mt-3 flex gap-3 text-xs">
-            {(["hit", "early", "late", "miss"] as TimingJudgment[]).map(
-              (j) => {
-                const count = timingEvents.filter(
-                  (e) => e.judgment === j,
-                ).length;
-                if (count === 0) return null;
-                return (
-                  <span key={j} className={judgmentColors[j]}>
-                    {judgmentLabels[j]}: {count}
-                  </span>
-                );
-              },
-            )}
-          </div>
-        </div>
-      )}
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {(["hit", "early", "late", "miss"] as TimingJudgment[]).map(
+                (j) => {
+                  const count = timingEvents.filter(
+                    (e) => e.judgment === j,
+                  ).length;
+                  if (!count) return null;
+                  return (
+                    <span
+                      key={j}
+                      style={{
+                        padding: "4px 12px",
+                        borderRadius: 8,
+                        background: JUDGMENT_CONFIG[j].bg,
+                        color: JUDGMENT_CONFIG[j].color,
+                        font: "500 12px/1.5 Roboto, sans-serif",
+                      }}
+                    >
+                      {JUDGMENT_CONFIG[j].label}: {count}
+                    </span>
+                  );
+                },
+              )}
+            </div>
+          </Card>
+        )}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,92 @@
 @import "tailwindcss";
 
+/* ── MD3 Color Tokens (dark, teal seed) ─────────────────────────────── */
+:root {
+  --md-primary: #4ecdc4;
+  --md-on-primary: #00201f;
+  --md-primary-container: #00413e;
+  --md-on-primary-container: #70efde;
+  --md-secondary: #b2ccc9;
+  --md-on-secondary: #1c3432;
+  --md-secondary-container: #334b49;
+  --md-on-secondary-container: #cee8e5;
+  --md-background: #191c1d;
+  --md-on-background: #e1e3e3;
+  --md-surface: #191c1d;
+  --md-on-surface: #e1e3e3;
+  --md-surface-variant: #3f4948;
+  --md-on-surface-variant: #bec9c8;
+  --md-outline: #889393;
+  --md-outline-variant: #3f4948;
+  --md-surface-container-lowest: #131617;
+  --md-surface-container-low: #1e2122;
+  --md-surface-container: #222627;
+  --md-surface-container-high: #2d3031;
+  --md-surface-container-highest: #37393b;
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html,
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, sans-serif;
-  background: #0f172a;
-  color: #e2e8f0;
+  padding: 0;
+  height: 100%;
+  background: var(--md-background);
+  color: var(--md-on-surface);
+  font-family: "Roboto", system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
 
 #root {
   min-height: 100svh;
+  height: 100%;
+}
+
+::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--md-outline-variant);
+  border-radius: 4px;
+}
+
+@keyframes md3-level-pulse {
+  from {
+    width: 45%;
+  }
+  to {
+    width: 75%;
+  }
+}
+@keyframes md3-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes md3-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.page-enter {
+  animation: md3-slide-up 0.25s ease-out;
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,20 +1,63 @@
 import { PresetCard } from "../components/practice/PresetCard";
+import { AssistChip, SectionLabel } from "../components/md3";
 import { tabPresets } from "../data/tabPresets";
 
 export function HomePage() {
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-semibold text-white mb-1">Tab Practice</h2>
-        <p className="text-sm text-slate-400">
-          メトロノームに合わせてタブ譜を演奏しよう。タイミングの正確さを評価します。
-        </p>
+    <div
+      style={{
+        padding: "24px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
+      {/* Hero */}
+      <div
+        style={{
+          background: "var(--md-primary-container)",
+          borderRadius: 24,
+          padding: "24px 24px 20px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            font: "300 13px/1 Roboto, sans-serif",
+            color: "var(--md-on-primary-container)",
+            opacity: 0.8,
+            letterSpacing: 1,
+            textTransform: "uppercase",
+          }}
+        >
+          Bass Practice
+        </div>
+        <div
+          style={{
+            font: "400 22px/1.3 Roboto, sans-serif",
+            color: "var(--md-on-primary-container)",
+          }}
+        >
+          タブ譜に合わせて演奏し、
+          <br />
+          タイミングの正確さを磨こう。
+        </div>
+        <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
+          <AssistChip label="🎸 メトロノーム付き" />
+          <AssistChip label="🎤 マイク検知" />
+        </div>
       </div>
 
-      <div className="grid gap-4">
-        {tabPresets.map((preset) => (
-          <PresetCard key={preset.id} preset={preset} />
-        ))}
+      {/* Preset list */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <SectionLabel>タブ譜を選ぶ</SectionLabel>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {tabPresets.map((preset) => (
+            <PresetCard key={preset.id} preset={preset} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -6,6 +6,7 @@ import { useTabPractice } from "../hooks/useTabPractice";
 import { AsciiTabDisplay } from "../components/practice/AsciiTabDisplay";
 import { MetronomeControls } from "../components/practice/MetronomeControls";
 import { TimingFeedback } from "../components/practice/TimingFeedback";
+import { Tag } from "../components/md3";
 import type { TabPreset } from "../types/practice";
 
 export function TabPracticePage() {
@@ -14,9 +15,25 @@ export function TabPracticePage() {
 
   if (!preset) {
     return (
-      <div className="text-center py-12">
-        <h2 className="text-xl text-slate-400 mb-4">Preset not found</h2>
-        <Link to="/" className="text-cyan-400 hover:text-cyan-300">
+      <div
+        style={{
+          textAlign: "center",
+          padding: "48px 16px",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        <h2
+          style={{
+            font: "400 20px/1.2 Roboto, sans-serif",
+            marginBottom: 16,
+          }}
+        >
+          Preset not found
+        </h2>
+        <Link
+          to="/"
+          style={{ color: "var(--md-primary)", textDecoration: "none" }}
+        >
           ← Back to Home
         </Link>
       </div>
@@ -38,7 +55,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
   const handleStart = async () => {
     setStartError(null);
     if (!audio.isListening) {
-      audio.start().catch(() => {}); // mic failure is non-fatal; onset detection just won't work
+      audio.start().catch(() => {});
     }
     try {
       await practice.startSession();
@@ -51,35 +68,47 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
   const micWarning = !startError && audio.error ? audio.error : null;
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <Link
-            to="/"
-            className="text-sm text-slate-400 hover:text-slate-300 mb-1 inline-block"
-          >
-            ← Back
-          </Link>
-          <h2 className="text-xl font-semibold text-white">{preset.name}</h2>
-          <p className="text-sm text-slate-400">{preset.description}</p>
-        </div>
-        <div className="text-right">
-          <div className="text-sm text-slate-500">
-            {preset.timeSignature.beatsPerMeasure}/{preset.timeSignature.beatUnit} ·{" "}
-            {preset.measures} measures
-          </div>
+    <div
+      style={{
+        padding: "24px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            font: "400 14px/1.5 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+            flex: 1,
+          }}
+        >
+          {preset.description}
+        </p>
+        <div style={{ display: "flex", gap: 8 }}>
+          <Tag
+            label={`${preset.timeSignature.beatsPerMeasure}/${preset.timeSignature.beatUnit}`}
+          />
+          <Tag label={`${preset.measures} 小節`} />
         </div>
       </div>
 
-      {/* Tab Display */}
       <AsciiTabDisplay
         preset={preset}
         currentBeat={practice.currentBeat}
         isPlaying={practice.phase === "playing"}
       />
 
-      {/* Controls */}
       <MetronomeControls
         bpm={practice.metronome.bpm}
         isPlaying={practice.metronome.isPlaying}
@@ -92,19 +121,34 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
       {displayedError && (
         <div
           role="alert"
-          className="bg-red-950/40 border border-red-800 text-red-200 text-sm rounded px-4 py-3"
+          style={{
+            background: "#ef53501a",
+            border: "1px solid #ef535066",
+            color: "#ef5350",
+            borderRadius: 12,
+            padding: "12px 16px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+          }}
         >
           {displayedError}
         </div>
       )}
 
       {micWarning && (
-        <div className="bg-yellow-950/40 border border-yellow-800 text-yellow-200 text-sm rounded px-4 py-3">
+        <div
+          style={{
+            background: "#f9a8251a",
+            border: "1px solid #f9a82566",
+            color: "#f9a825",
+            borderRadius: 12,
+            padding: "12px 16px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+          }}
+        >
           🎤 マイクが利用できません（メトロノームは動作します）: {micWarning}
         </div>
       )}
 
-      {/* Feedback */}
       <TimingFeedback
         lastEvent={practice.lastEvent}
         stats={practice.stats}

--- a/src/pages/TunerPage.tsx
+++ b/src/pages/TunerPage.tsx
@@ -9,7 +9,16 @@ export function TunerPage() {
   const { pitch } = usePitchDetection(audio.engine, audio.isListening);
 
   return (
-    <div className="space-y-6">
+    <div
+      style={{
+        padding: "24px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
+      <PitchDisplay pitch={audio.isListening ? pitch : null} />
+
       <AudioSetup
         isListening={audio.isListening}
         isPermissionGranted={audio.isPermissionGranted}
@@ -26,8 +35,6 @@ export function TunerPage() {
         clarityThreshold={audio.clarityThreshold}
         onThresholdChange={audio.setClarityThreshold}
       />
-
-      {audio.isListening && <PitchDisplay pitch={pitch} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Claude Design で作成した MD3 プロトタイプをコードへ移植（ダークテーマ / ティールシード）
- 共通 MD3 コンポーネント（`src/components/md3.tsx`）を新設し、Layout / ページ / 各機能コンポーネントを刷新
- タブ譜を SVG グラフィカル表示（弦の太さ・丸ノート・自動スクロール）に、チューナーをアークゲージ針式表示に変更

## 主な変更
| 要素 | 変更内容 |
|---|---|
| カラー | slate-900 → MD3 ダークテーマ (ティール) |
| ナビゲーション | ヘッダーリンク → TopAppBar + BottomNav |
| カード | MD3 Surface Container Elevated |
| ボタン | Filled / Outlined |
| スライダー | カスタム MD3 スライダー（thumb + track） |
| タブ譜 | ASCII → SVG フレットボード風 |
| チューナー | ゲージバー → アーク + 針アニメーション |
| タイミング | テキスト → カラーバッジ + バーグラフ + 統計グリッド |
| フォント | system-ui → Roboto / Roboto Mono |

## Test plan
- [x] `npm run build` が成功
- [x] `npm run lint` クリーン
- [x] `npm test` 160 件すべて成功
- [ ] ローカルで `npm run dev` → ホーム / チューナー / タブ練習の画面を目視確認
- [ ] モバイル幅（〜480px）で BottomNav / 練習画面の戻るボタンを確認
- [ ] マイクを有効化しチューナーのアーク針が動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)