### PR TITLE
feat: レスポンシブ対応 - デスクトップ表示の最適化

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,12 @@
 import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
 import { tabPresets } from "../data/tabPresets";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 
 export function Layout() {
   const location = useLocation();
   const navigate = useNavigate();
   const params = useParams();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const isPractice = location.pathname.startsWith("/practice/tab/");
   const practicePreset = isPractice
@@ -23,33 +25,50 @@ export function Layout() {
     <div
       style={{
         display: "flex",
-        flexDirection: "column",
+        flexDirection: isDesktop ? "row" : "column",
         minHeight: "100dvh",
-        maxWidth: 480,
-        margin: "0 auto",
         position: "relative",
         background: "var(--md-background)",
       }}
     >
-      <TopAppBar
-        title={title}
-        onBack={isPractice ? () => navigate("/") : undefined}
-      />
-
-      <main
-        key={location.pathname}
-        className="page-enter"
-        style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}
-      >
-        <Outlet />
-      </main>
-
-      {!isPractice && (
-        <BottomNav
+      {isDesktop && !isPractice && (
+        <SideNav
           current={currentTab}
           onChange={(id) => navigate(id === "home" ? "/" : "/tuner")}
         />
       )}
+
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          minHeight: "100dvh",
+          maxWidth: isDesktop ? 960 : undefined,
+          margin: isDesktop ? "0 auto" : undefined,
+          width: isDesktop ? "100%" : undefined,
+        }}
+      >
+        <TopAppBar
+          title={title}
+          onBack={isPractice ? () => navigate("/") : undefined}
+        />
+
+        <main
+          key={location.pathname}
+          className="page-enter"
+          style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}
+        >
+          <Outlet />
+        </main>
+
+        {!isPractice && !isDesktop && (
+          <BottomNav
+            current={currentTab}
+            onChange={(id) => navigate(id === "home" ? "/" : "/tuner")}
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -112,16 +131,75 @@ function TopAppBar({ title, onBack }: TopAppBarProps) {
   );
 }
 
-interface BottomNavProps {
+interface NavProps {
   current: "home" | "tuner";
   onChange: (id: "home" | "tuner") => void;
 }
 
-function BottomNav({ current, onChange }: BottomNavProps) {
-  const items: { id: "home" | "tuner"; label: string; icon: string }[] = [
-    { id: "home", label: "ホーム", icon: "⊟" },
-    { id: "tuner", label: "チューナー", icon: "♩" },
-  ];
+const NAV_ITEMS: { id: "home" | "tuner"; label: string; icon: string }[] = [
+  { id: "home", label: "ホーム", icon: "⊟" },
+  { id: "tuner", label: "チューナー", icon: "♩" },
+];
+
+function SideNav({ current, onChange }: NavProps) {
+  return (
+    <nav
+      style={{
+        width: 240,
+        flexShrink: 0,
+        background: "var(--md-surface-container)",
+        borderRight: "1px solid var(--md-outline-variant)",
+        display: "flex",
+        flexDirection: "column",
+        padding: "16px 12px",
+        gap: 4,
+      }}
+    >
+      <div
+        style={{
+          font: "500 18px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface)",
+          padding: "12px 16px 20px",
+          letterSpacing: -0.2,
+        }}
+      >
+        🎸 Bass Practice
+      </div>
+      {NAV_ITEMS.map((item) => {
+        const active = current === item.id;
+        return (
+          <button
+            key={item.id}
+            onClick={() => onChange(item.id)}
+            style={{
+              background: active
+                ? "var(--md-secondary-container)"
+                : "transparent",
+              border: "none",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              padding: "12px 16px",
+              borderRadius: 28,
+              color: active
+                ? "var(--md-on-secondary-container)"
+                : "var(--md-on-surface-variant)",
+              font: `${active ? "500" : "400"} 14px/1 Roboto, sans-serif`,
+              letterSpacing: 0.2,
+              transition: "background 0.15s, color 0.15s",
+            }}
+          >
+            <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
+            {item.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function BottomNav({ current, onChange }: NavProps) {
   return (
     <nav
       style={{
@@ -133,7 +211,7 @@ function BottomNav({ current, onChange }: BottomNavProps) {
         paddingBottom: "env(safe-area-inset-bottom)",
       }}
     >
-      {items.map((item) => {
+      {NAV_ITEMS.map((item) => {
         const active = current === item.id;
         return (
           <button

--- a/src/components/audio/PitchDisplay.tsx
+++ b/src/components/audio/PitchDisplay.tsx
@@ -3,9 +3,10 @@ import { Card } from "../md3";
 
 interface PitchDisplayProps {
   pitch: PitchResult | null;
+  gaugeSize?: number;
 }
 
-export function PitchDisplay({ pitch }: PitchDisplayProps) {
+export function PitchDisplay({ pitch, gaugeSize = 240 }: PitchDisplayProps) {
   const isActive = pitch?.detected === true;
   const cents = isActive ? pitch.cents : 0;
   const abs = Math.abs(cents);
@@ -50,12 +51,12 @@ export function PitchDisplay({ pitch }: PitchDisplayProps) {
         </div>
       </div>
 
-      <CentsGauge cents={cents} active={isActive} />
+      <CentsGauge cents={cents} active={isActive} size={gaugeSize} />
     </Card>
   );
 }
 
-function CentsGauge({ cents, active }: { cents: number; active: boolean }) {
+function CentsGauge({ cents, active, size = 240 }: { cents: number; active: boolean; size?: number }) {
   const clamped = Math.max(-50, Math.min(50, cents));
   const abs = Math.abs(cents);
   const colorHex =
@@ -63,6 +64,17 @@ function CentsGauge({ cents, active }: { cents: number; active: boolean }) {
   const colorClass =
     abs <= 10 ? "bg-emerald-500" : abs <= 25 ? "bg-yellow-500" : "bg-red-500";
   const label = abs <= 5 ? "IN TUNE" : clamped < 0 ? "FLAT" : "SHARP";
+
+  // Scale everything relative to base size of 240
+  const scale = size / 240;
+  const svgW = size;
+  const svgH = Math.round(130 * scale);
+  const cx = size / 2;
+  const cy = svgH - Math.round(10 * scale);
+  const radius = Math.round(100 * scale);
+  const sw = Math.round(12 * scale);
+  const pad = Math.round(20 * scale);
+  const needleH = Math.round(100 * scale);
 
   return (
     <div
@@ -77,51 +89,51 @@ function CentsGauge({ cents, active }: { cents: number; active: boolean }) {
       <div
         style={{
           position: "relative",
-          width: 240,
-          height: 130,
+          width: svgW,
+          height: svgH,
           overflow: "hidden",
         }}
       >
         <svg
-          width="240"
-          height="130"
-          viewBox="0 0 240 130"
+          width={svgW}
+          height={svgH}
+          viewBox={`0 0 ${svgW} ${svgH}`}
           style={{ position: "absolute", top: 0, left: 0 }}
         >
           <path
-            d="M 20 120 A 100 100 0 0 1 220 120"
+            d={`M ${pad} ${cy} A ${radius} ${radius} 0 0 1 ${svgW - pad} ${cy}`}
             fill="none"
             stroke="var(--md-surface-container-highest)"
-            strokeWidth="12"
+            strokeWidth={sw}
             strokeLinecap="round"
           />
           {active && (
             <path
-              d="M 20 120 A 100 100 0 0 1 220 120"
+              d={`M ${pad} ${cy} A ${radius} ${radius} 0 0 1 ${svgW - pad} ${cy}`}
               fill="none"
               stroke={colorHex + "44"}
-              strokeWidth="12"
+              strokeWidth={sw}
               strokeLinecap="round"
             />
           )}
           <line
-            x1="120"
-            y1="20"
-            x2="120"
-            y2="40"
+            x1={cx}
+            y1={cy - radius - Math.round(6 * scale)}
+            x2={cx}
+            y2={cy - radius + Math.round(14 * scale)}
             stroke="var(--md-outline)"
             strokeWidth="2"
             strokeLinecap="round"
           />
           {[-50, -25, 0, 25, 50].map((t) => {
             const angle = (t / 50) * 75;
-            const rad = ((90 + angle) * Math.PI) / 180;
-            const r1 = 94;
-            const r2 = 104;
-            const x1 = 120 + r1 * Math.cos(Math.PI - rad);
-            const y1 = 120 - r1 * Math.sin(Math.PI - rad);
-            const x2 = 120 + r2 * Math.cos(Math.PI - rad);
-            const y2 = 120 - r2 * Math.sin(Math.PI - rad);
+            const rad2 = ((90 + angle) * Math.PI) / 180;
+            const r1 = radius - Math.round(6 * scale);
+            const r2 = radius + Math.round(4 * scale);
+            const x1 = cx + r1 * Math.cos(Math.PI - rad2);
+            const y1 = cy - r1 * Math.sin(Math.PI - rad2);
+            const x2 = cx + r2 * Math.cos(Math.PI - rad2);
+            const y2 = cy - r2 * Math.sin(Math.PI - rad2);
             return (
               <line
                 key={t}
@@ -143,7 +155,7 @@ function CentsGauge({ cents, active }: { cents: number; active: boolean }) {
               bottom: 0,
               left: "50%",
               width: 2,
-              height: 100,
+              height: needleH,
               transformOrigin: "bottom center",
               transform: `translateX(-50%) rotate(${(clamped / 50) * 75}deg)`,
               background: colorHex,

--- a/src/components/practice/AsciiTabDisplay.tsx
+++ b/src/components/practice/AsciiTabDisplay.tsx
@@ -40,7 +40,7 @@ export function AsciiTabDisplay({
     if (!isPlaying || currentBeat < 0 || !scrollRef.current) return;
     const x = LABEL_W + currentBeat * BEAT_W - 80;
     scrollRef.current.scrollTo({ left: Math.max(0, x), behavior: "smooth" });
-  }, [currentBeat, isPlaying]);
+  }, [currentBeat, isPlaying, BEAT_W]);
 
   const svgW = LABEL_W + totalBeats * BEAT_W + PADDING;
   const svgH = 4 * ROW_H + 32;

--- a/src/components/practice/AsciiTabDisplay.tsx
+++ b/src/components/practice/AsciiTabDisplay.tsx
@@ -6,11 +6,12 @@ interface AsciiTabDisplayProps {
   preset: TabPreset;
   currentBeat: number;
   isPlaying: boolean;
+  beatWidth?: number;
 }
 
 const STRING_LABELS = ["G", "D", "A", "E"];
 const STRING_THICKNESS = [1, 1.5, 2, 2.5];
-const BEAT_W = 48;
+const DEFAULT_BEAT_W = 48;
 const ROW_H = 52;
 const LABEL_W = 36;
 const PADDING = 16;
@@ -19,7 +20,9 @@ export function AsciiTabDisplay({
   preset,
   currentBeat,
   isPlaying,
+  beatWidth = DEFAULT_BEAT_W,
 }: AsciiTabDisplayProps) {
+  const BEAT_W = beatWidth;
   const totalBeats = preset.timeSignature.beatsPerMeasure * preset.measures;
   const bpm = preset.timeSignature.beatsPerMeasure;
   const scrollRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/practice/PresetCard.tsx
+++ b/src/components/practice/PresetCard.tsx
@@ -45,6 +45,7 @@ export function PresetCard({ preset }: PresetCardProps) {
         flexDirection: "column",
         gap: 8,
         color: "var(--md-on-surface)",
+        height: "100%",
       }}
     >
       <div

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    setMatches(mql.matches);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,18 +1,21 @@
-import { useState, useEffect } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(query).matches;
-  });
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", onStoreChange);
+      return () => mql.removeEventListener("change", onStoreChange);
+    },
+    [query],
+  );
 
-  useEffect(() => {
-    const mql = window.matchMedia(query);
-    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
-    mql.addEventListener("change", handler);
-    setMatches(mql.matches);
-    return () => mql.removeEventListener("change", handler);
-  }, [query]);
+  const getSnapshot = useCallback(
+    () => window.matchMedia(query).matches,
+    [query],
+  );
 
-  return matches;
+  const getServerSnapshot = useCallback(() => false, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,12 +1,15 @@
 import { PresetCard } from "../components/practice/PresetCard";
 import { AssistChip, SectionLabel } from "../components/md3";
 import { tabPresets } from "../data/tabPresets";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 
 export function HomePage() {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
   return (
     <div
       style={{
-        padding: "24px 16px",
+        padding: isDesktop ? "32px 32px" : "24px 16px",
         display: "flex",
         flexDirection: "column",
         gap: 24,
@@ -17,7 +20,7 @@ export function HomePage() {
         style={{
           background: "var(--md-primary-container)",
           borderRadius: 24,
-          padding: "24px 24px 20px",
+          padding: isDesktop ? "32px 40px 28px" : "24px 24px 20px",
           display: "flex",
           flexDirection: "column",
           gap: 8,
@@ -36,7 +39,7 @@ export function HomePage() {
         </div>
         <div
           style={{
-            font: "400 22px/1.3 Roboto, sans-serif",
+            font: `400 ${isDesktop ? 26 : 22}px/1.3 Roboto, sans-serif`,
             color: "var(--md-on-primary-container)",
           }}
         >
@@ -53,7 +56,13 @@ export function HomePage() {
       {/* Preset list */}
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <SectionLabel>タブ譜を選ぶ</SectionLabel>
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: isDesktop ? "1fr 1fr" : "1fr",
+            gap: 12,
+          }}
+        >
           {tabPresets.map((preset) => (
             <PresetCard key={preset.id} preset={preset} />
           ))}

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -7,6 +7,7 @@ import { AsciiTabDisplay } from "../components/practice/AsciiTabDisplay";
 import { MetronomeControls } from "../components/practice/MetronomeControls";
 import { TimingFeedback } from "../components/practice/TimingFeedback";
 import { Tag } from "../components/md3";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 import type { TabPreset } from "../types/practice";
 
 export function TabPracticePage() {
@@ -51,6 +52,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
   const audio = useAudioInput();
   const practice = useTabPractice(preset, audio.engine);
   const [startError, setStartError] = useState<string | null>(null);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const handleStart = async () => {
     setStartError(null);
@@ -67,10 +69,45 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
   const displayedError = startError;
   const micWarning = !startError && audio.error ? audio.error : null;
 
+  const errorBlock = (
+    <>
+      {displayedError && (
+        <div
+          role="alert"
+          style={{
+            background: "#ef53501a",
+            border: "1px solid #ef535066",
+            color: "#ef5350",
+            borderRadius: 12,
+            padding: "12px 16px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+          }}
+        >
+          {displayedError}
+        </div>
+      )}
+
+      {micWarning && (
+        <div
+          style={{
+            background: "#f9a8251a",
+            border: "1px solid #f9a82566",
+            color: "#f9a825",
+            borderRadius: 12,
+            padding: "12px 16px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+          }}
+        >
+          🎤 マイクが利用できません（メトロノームは動作します）: {micWarning}
+        </div>
+      )}
+    </>
+  );
+
   return (
     <div
       style={{
-        padding: "24px 16px",
+        padding: isDesktop ? "32px 32px" : "24px 16px",
         display: "flex",
         flexDirection: "column",
         gap: 16,
@@ -107,55 +144,57 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
         preset={preset}
         currentBeat={practice.currentBeat}
         isPlaying={practice.phase === "playing"}
+        beatWidth={isDesktop ? 64 : 48}
       />
 
-      <MetronomeControls
-        bpm={practice.metronome.bpm}
-        isPlaying={practice.metronome.isPlaying}
-        phase={practice.phase}
-        onBpmChange={practice.metronome.setBpm}
-        onStart={handleStart}
-        onStop={practice.stopSession}
-      />
-
-      {displayedError && (
-        <div
-          role="alert"
-          style={{
-            background: "#ef53501a",
-            border: "1px solid #ef535066",
-            color: "#ef5350",
-            borderRadius: 12,
-            padding: "12px 16px",
-            font: "400 13px/1.5 Roboto, sans-serif",
-          }}
-        >
-          {displayedError}
-        </div>
-      )}
-
-      {micWarning && (
+      {isDesktop ? (
         <div
           style={{
-            background: "#f9a8251a",
-            border: "1px solid #f9a82566",
-            color: "#f9a825",
-            borderRadius: 12,
-            padding: "12px 16px",
-            font: "400 13px/1.5 Roboto, sans-serif",
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 16,
+            alignItems: "start",
           }}
         >
-          🎤 マイクが利用できません（メトロノームは動作します）: {micWarning}
+          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <MetronomeControls
+              bpm={practice.metronome.bpm}
+              isPlaying={practice.metronome.isPlaying}
+              phase={practice.phase}
+              onBpmChange={practice.metronome.setBpm}
+              onStart={handleStart}
+              onStop={practice.stopSession}
+            />
+            {errorBlock}
+          </div>
+          <TimingFeedback
+            lastEvent={practice.lastEvent}
+            stats={practice.stats}
+            phase={practice.phase}
+            timingEvents={practice.timingEvents}
+            loop={practice.loop}
+          />
         </div>
+      ) : (
+        <>
+          <MetronomeControls
+            bpm={practice.metronome.bpm}
+            isPlaying={practice.metronome.isPlaying}
+            phase={practice.phase}
+            onBpmChange={practice.metronome.setBpm}
+            onStart={handleStart}
+            onStop={practice.stopSession}
+          />
+          {errorBlock}
+          <TimingFeedback
+            lastEvent={practice.lastEvent}
+            stats={practice.stats}
+            phase={practice.phase}
+            timingEvents={practice.timingEvents}
+            loop={practice.loop}
+          />
+        </>
       )}
-
-      <TimingFeedback
-        lastEvent={practice.lastEvent}
-        stats={practice.stats}
-        phase={practice.phase}
-        timingEvents={practice.timingEvents}
-        loop={practice.loop}
-      />
     </div>
   );
 }

--- a/src/pages/TunerPage.tsx
+++ b/src/pages/TunerPage.tsx
@@ -3,38 +3,79 @@ import { PitchDisplay } from "../components/audio/PitchDisplay";
 import { SensitivitySlider } from "../components/audio/SensitivitySlider";
 import { useAudioInput } from "../hooks/useAudioInput";
 import { usePitchDetection } from "../hooks/usePitchDetection";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 
 export function TunerPage() {
   const audio = useAudioInput();
   const { pitch } = usePitchDetection(audio.engine, audio.isListening);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   return (
     <div
       style={{
-        padding: "24px 16px",
+        padding: isDesktop ? "32px 32px" : "24px 16px",
         display: "flex",
         flexDirection: "column",
         gap: 16,
       }}
     >
-      <PitchDisplay pitch={audio.isListening ? pitch : null} />
-
-      <AudioSetup
-        isListening={audio.isListening}
-        isPermissionGranted={audio.isPermissionGranted}
-        inputLevel={audio.inputLevel}
-        availableDevices={audio.availableDevices}
-        selectedDeviceId={audio.selectedDeviceId}
-        error={audio.error}
-        onStart={audio.start}
-        onStop={audio.stop}
-        onSwitchDevice={audio.switchDevice}
-      />
-
-      <SensitivitySlider
-        clarityThreshold={audio.clarityThreshold}
-        onThresholdChange={audio.setClarityThreshold}
-      />
+      {isDesktop ? (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 16,
+            alignItems: "start",
+          }}
+        >
+          <PitchDisplay
+            pitch={audio.isListening ? pitch : null}
+            gaugeSize={320}
+          />
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 16,
+            }}
+          >
+            <AudioSetup
+              isListening={audio.isListening}
+              isPermissionGranted={audio.isPermissionGranted}
+              inputLevel={audio.inputLevel}
+              availableDevices={audio.availableDevices}
+              selectedDeviceId={audio.selectedDeviceId}
+              error={audio.error}
+              onStart={audio.start}
+              onStop={audio.stop}
+              onSwitchDevice={audio.switchDevice}
+            />
+            <SensitivitySlider
+              clarityThreshold={audio.clarityThreshold}
+              onThresholdChange={audio.setClarityThreshold}
+            />
+          </div>
+        </div>
+      ) : (
+        <>
+          <PitchDisplay pitch={audio.isListening ? pitch : null} />
+          <AudioSetup
+            isListening={audio.isListening}
+            isPermissionGranted={audio.isPermissionGranted}
+            inputLevel={audio.inputLevel}
+            availableDevices={audio.availableDevices}
+            selectedDeviceId={audio.selectedDeviceId}
+            error={audio.error}
+            onStart={audio.start}
+            onStop={audio.stop}
+            onSwitchDevice={audio.switchDevice}
+          />
+          <SensitivitySlider
+            clarityThreshold={audio.clarityThreshold}
+            onThresholdChange={audio.setClarityThreshold}
+          />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

Issue #40 の対応。デスクトップ(≥768px)での表示を最適化し、スペースを有効活用するレスポンシブレイアウトを実装。

## 変更内容

### Phase 1: Layout のレスポンシブ化
- `maxWidth: 480px` を削除
- デスクトップで **SideNav**(左サイドバー)表示、BottomNav 非表示
- モバイルで **BottomNav** 維持、SideNav 非表示
- メインコンテンツ領域に `max-width: 960px` + `margin: 0 auto` を設定

### Phase 2: ページごとの最適化
- **HomePage**: PresetCard を 2カラムグリッド表示(`grid-cols-2`)
- **TunerPage**: PitchDisplay と AudioSetup + SensitivitySlider を横並び2カラム配置、CentsGauge をデスクトップで 320px に拡大
- **TabPracticePage**: タブ譜をフル幅で表示、MetronomeControls と TimingFeedback を横並び配置、`BEAT_W` をデスクトップで 64px に拡大

### Phase 3: コンポーネント調整
- **PresetCard**: `height: 100%` でグリッド対応
- **PitchDisplay**: `gaugeSize` props で CentsGauge サイズ可変に
- **AsciiTabDisplay**: `beatWidth` props で BEAT_W 可変に
- **useMediaQuery** カスタムフックを新規作成

## 新規ファイル
- `src/hooks/useMediaQuery.ts`

## 確認事項
- [x] デスクトップ(≥768px)で SideNav 表示、BottomNav 非表示
- [x] モバイル(<768px)で BottomNav 表示、SideNav 非表示
- [x] HomePage の PresetCard がデスクトップで 2カラムグリッド
- [x] TunerPage がデスクトップで 2カラム横並びレイアウト
- [x] TabPracticePage がデスクトップでスペースを有効活用
- [x] 既存のモバイル表示が壊れていないこと
- [x] `npm run build` が通ること
- [x] 全160テスト pass

Closes #40