### PR TITLE
feat: BPMの段階的アップ機能

### DIFF
--- a/src/components/practice/AutoBpmControls.tsx
+++ b/src/components/practice/AutoBpmControls.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { AutoBpmConfig } from "../../hooks/useAutoBpm";
 import type { TabSessionPhase } from "../../types/practice";
 import { Card, Md3Slider } from "../md3";
@@ -31,194 +32,26 @@ export function AutoBpmControls({
 
   return (
     <Card style={{ padding: 20 }}>
-      {/* Header with toggle */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: config.enabled ? 16 : 0,
-        }}
-      >
-        <div
-          style={{
-            font: "500 16px/1 Roboto, sans-serif",
-            color: "var(--md-on-surface)",
-          }}
-        >
-          Auto BPM Up
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={config.enabled}
-          aria-label="Auto BPM Up"
-          disabled={active}
-          onClick={() => onEnabledChange(!config.enabled)}
-          style={{
-            position: "relative",
-            width: 52,
-            height: 32,
-            borderRadius: 16,
-            border: config.enabled
-              ? "none"
-              : "2px solid var(--md-outline)",
-            background: config.enabled
-              ? "var(--md-primary)"
-              : "var(--md-surface-container-highest)",
-            cursor: active ? "not-allowed" : "pointer",
-            opacity: active ? 0.5 : 1,
-            padding: 0,
-            transition: "background 0.2s",
-          }}
-        >
-          <div
-            style={{
-              position: "absolute",
-              top: config.enabled ? 4 : 6,
-              left: config.enabled ? 24 : 6,
-              width: config.enabled ? 24 : 16,
-              height: config.enabled ? 24 : 16,
-              borderRadius: 12,
-              background: config.enabled
-                ? "var(--md-on-primary)"
-                : "var(--md-outline)",
-              transition: "left 0.2s, width 0.2s, height 0.2s, top 0.2s",
-            }}
-          />
-        </button>
-      </div>
+      <Header
+        enabled={config.enabled}
+        locked={active}
+        marginBottom={config.enabled ? 16 : 0}
+        onToggle={() => onEnabledChange(!config.enabled)}
+      />
 
       {config.enabled && (
         <>
-          {/* Notification banner */}
-          {notification && (
-            <div
-              style={{
-                background:
-                  "color-mix(in srgb, var(--md-primary) 10%, transparent)",
-                border:
-                  "1px solid color-mix(in srgb, var(--md-primary) 40%, transparent)",
-                color: "var(--md-primary)",
-                borderRadius: 12,
-                padding: "10px 16px",
-                font: "600 14px/1.5 Roboto, sans-serif",
-                textAlign: "center",
-                marginBottom: 16,
-                animation: "fadeIn 0.3s ease-out",
-              }}
-            >
-              {notification}
-            </div>
-          )}
+          {notification && <NotificationBanner message={notification} />}
 
-          {/* BPM progress display */}
           {active && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: 12,
-                marginBottom: 16,
-                padding: "12px 0",
-              }}
-            >
-              <div style={{ textAlign: "center" }}>
-                <div
-                  style={{
-                    font: "400 11px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                    marginBottom: 4,
-                  }}
-                >
-                  Start
-                </div>
-                <div
-                  style={{
-                    font: "700 20px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                  }}
-                  className="tabular-nums"
-                >
-                  {startBpm}
-                </div>
-              </div>
-              <div
-                style={{
-                  font: "400 18px/1 Roboto, sans-serif",
-                  color: "var(--md-on-surface-variant)",
-                }}
-              >
-                →
-              </div>
-              <div style={{ textAlign: "center" }}>
-                <div
-                  style={{
-                    font: "400 11px/1 Roboto, sans-serif",
-                    color: "var(--md-primary)",
-                    marginBottom: 4,
-                  }}
-                >
-                  Current
-                </div>
-                <div
-                  style={{
-                    font: "700 24px/1 Roboto, sans-serif",
-                    color: "var(--md-primary)",
-                  }}
-                  className="tabular-nums"
-                >
-                  {currentBpm}
-                </div>
-              </div>
-              <div
-                style={{
-                  font: "400 18px/1 Roboto, sans-serif",
-                  color: "var(--md-on-surface-variant)",
-                }}
-              >
-                →
-              </div>
-              <div style={{ textAlign: "center" }}>
-                <div
-                  style={{
-                    font: "400 11px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                    marginBottom: 4,
-                  }}
-                >
-                  Max
-                </div>
-                <div
-                  style={{
-                    font: "700 20px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                  }}
-                  className="tabular-nums"
-                >
-                  {config.maxBpm}
-                </div>
-              </div>
-              {levelUps > 0 && (
-                <span
-                  style={{
-                    marginLeft: 8,
-                    padding: "4px 10px",
-                    borderRadius: 12,
-                    background:
-                      "color-mix(in srgb, var(--md-primary) 10%, transparent)",
-                    color: "var(--md-primary)",
-                    font: "600 12px/1.5 Roboto, sans-serif",
-                  }}
-                >
-                  +{levelUps}
-                </span>
-              )}
-            </div>
+            <BpmProgress
+              startBpm={startBpm}
+              currentBpm={currentBpm}
+              maxBpm={config.maxBpm}
+              levelUps={levelUps}
+            />
           )}
 
-          {/* Settings (disabled while playing) */}
           <div
             style={{
               display: "flex",
@@ -228,122 +61,308 @@ export function AutoBpmControls({
               pointerEvents: active ? "none" : "auto",
             }}
           >
-            {/* Hit Rate Threshold */}
-            <div>
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  marginBottom: 4,
-                }}
-              >
-                <span
-                  style={{
-                    font: "400 13px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                  }}
-                >
-                  Hit Rate 閾値
-                </span>
-                <span
-                  style={{
-                    font: "500 13px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface)",
-                  }}
-                  className="tabular-nums"
-                >
-                  {Math.round(config.hitRateThreshold * 100)}%
-                </span>
-              </div>
-              <Md3Slider
-                min={50}
-                max={100}
-                step={5}
-                value={Math.round(config.hitRateThreshold * 100)}
-                onChange={(v) => onThresholdChange(v / 100)}
-                disabled={active}
-                ariaLabel="Hit Rate Threshold"
-              />
-            </div>
-
-            {/* BPM Increment */}
-            <div>
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  marginBottom: 4,
-                }}
-              >
-                <span
-                  style={{
-                    font: "400 13px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                  }}
-                >
-                  BPM 増加量
-                </span>
-                <span
-                  style={{
-                    font: "500 13px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface)",
-                  }}
-                  className="tabular-nums"
-                >
-                  +{config.bpmIncrement}
-                </span>
-              </div>
-              <Md3Slider
-                min={1}
-                max={20}
-                step={1}
-                value={config.bpmIncrement}
-                onChange={onIncrementChange}
-                disabled={active}
-                ariaLabel="BPM Increment"
-              />
-            </div>
-
-            {/* Max BPM */}
-            <div>
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  marginBottom: 4,
-                }}
-              >
-                <span
-                  style={{
-                    font: "400 13px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface-variant)",
-                  }}
-                >
-                  BPM 上限
-                </span>
-                <span
-                  style={{
-                    font: "500 13px/1 Roboto, sans-serif",
-                    color: "var(--md-on-surface)",
-                  }}
-                  className="tabular-nums"
-                >
-                  {config.maxBpm}
-                </span>
-              </div>
-              <Md3Slider
-                min={40}
-                max={300}
-                step={5}
-                value={config.maxBpm}
-                onChange={onMaxBpmChange}
-                disabled={active}
-                ariaLabel="Max BPM"
-              />
-            </div>
+            <SettingSlider
+              label="Hit Rate 閾値"
+              valueText={`${Math.round(config.hitRateThreshold * 100)}%`}
+              min={50}
+              max={100}
+              step={5}
+              value={Math.round(config.hitRateThreshold * 100)}
+              onChange={(v) => onThresholdChange(v / 100)}
+              disabled={active}
+              ariaLabel="Hit Rate Threshold"
+            />
+            <SettingSlider
+              label="BPM 増加量"
+              valueText={`+${config.bpmIncrement}`}
+              min={1}
+              max={20}
+              step={1}
+              value={config.bpmIncrement}
+              onChange={onIncrementChange}
+              disabled={active}
+              ariaLabel="BPM Increment"
+            />
+            <SettingSlider
+              label="BPM 上限"
+              valueText={String(config.maxBpm)}
+              min={40}
+              max={300}
+              step={5}
+              value={config.maxBpm}
+              onChange={onMaxBpmChange}
+              disabled={active}
+              ariaLabel="Max BPM"
+            />
           </div>
         </>
       )}
     </Card>
+  );
+}
+
+// ---------- sub-components ----------
+
+interface HeaderProps {
+  enabled: boolean;
+  locked: boolean;
+  marginBottom: number;
+  onToggle: () => void;
+}
+
+function Header({ enabled, locked, marginBottom, onToggle }: HeaderProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom,
+      }}
+    >
+      <div
+        style={{
+          font: "500 16px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface)",
+        }}
+      >
+        Auto BPM Up
+      </div>
+      <ToggleSwitch enabled={enabled} locked={locked} onToggle={onToggle} />
+    </div>
+  );
+}
+
+interface ToggleSwitchProps {
+  enabled: boolean;
+  locked: boolean;
+  onToggle: () => void;
+}
+
+function ToggleSwitch({ enabled, locked, onToggle }: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label="Auto BPM Up"
+      disabled={locked}
+      onClick={onToggle}
+      style={{
+        position: "relative",
+        width: 52,
+        height: 32,
+        borderRadius: 16,
+        border: enabled ? "none" : "2px solid var(--md-outline)",
+        background: enabled
+          ? "var(--md-primary)"
+          : "var(--md-surface-container-highest)",
+        cursor: locked ? "not-allowed" : "pointer",
+        opacity: locked ? 0.5 : 1,
+        padding: 0,
+        transition: "background 0.2s",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: enabled ? 4 : 6,
+          left: enabled ? 24 : 6,
+          width: enabled ? 24 : 16,
+          height: enabled ? 24 : 16,
+          borderRadius: 12,
+          background: enabled ? "var(--md-on-primary)" : "var(--md-outline)",
+          transition: "left 0.2s, width 0.2s, height 0.2s, top 0.2s",
+        }}
+      />
+    </button>
+  );
+}
+
+function NotificationBanner({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        background:
+          "color-mix(in srgb, var(--md-primary) 10%, transparent)",
+        border:
+          "1px solid color-mix(in srgb, var(--md-primary) 40%, transparent)",
+        color: "var(--md-primary)",
+        borderRadius: 12,
+        padding: "10px 16px",
+        font: "600 14px/1.5 Roboto, sans-serif",
+        textAlign: "center",
+        marginBottom: 16,
+        animation: "fadeIn 0.3s ease-out",
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+interface BpmProgressProps {
+  startBpm: number;
+  currentBpm: number;
+  maxBpm: number;
+  levelUps: number;
+}
+
+function BpmProgress({
+  startBpm,
+  currentBpm,
+  maxBpm,
+  levelUps,
+}: BpmProgressProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 12,
+        marginBottom: 16,
+        padding: "12px 0",
+      }}
+    >
+      <BpmStage label="Start" value={startBpm} />
+      <Arrow />
+      <BpmStage label="Current" value={currentBpm} emphasis />
+      <Arrow />
+      <BpmStage label="Max" value={maxBpm} />
+      {levelUps > 0 && <LevelUpBadge count={levelUps} />}
+    </div>
+  );
+}
+
+function BpmStage({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: number;
+  emphasis?: boolean;
+}) {
+  const color = emphasis
+    ? "var(--md-primary)"
+    : "var(--md-on-surface-variant)";
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div
+        style={{
+          font: "400 11px/1 Roboto, sans-serif",
+          color,
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          font: emphasis
+            ? "700 24px/1 Roboto, sans-serif"
+            : "700 20px/1 Roboto, sans-serif",
+          color,
+        }}
+        className="tabular-nums"
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Arrow() {
+  return (
+    <div
+      style={{
+        font: "400 18px/1 Roboto, sans-serif",
+        color: "var(--md-on-surface-variant)",
+      }}
+    >
+      →
+    </div>
+  );
+}
+
+function LevelUpBadge({ count }: { count: number }) {
+  return (
+    <span
+      style={{
+        marginLeft: 8,
+        padding: "4px 10px",
+        borderRadius: 12,
+        background:
+          "color-mix(in srgb, var(--md-primary) 10%, transparent)",
+        color: "var(--md-primary)",
+        font: "600 12px/1.5 Roboto, sans-serif",
+      }}
+    >
+      +{count}
+    </span>
+  );
+}
+
+interface SettingSliderProps {
+  label: ReactNode;
+  valueText: ReactNode;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  onChange: (v: number) => void;
+  disabled: boolean;
+  ariaLabel: string;
+}
+
+function SettingSlider({
+  label,
+  valueText,
+  min,
+  max,
+  step,
+  value,
+  onChange,
+  disabled,
+  ariaLabel,
+}: SettingSliderProps) {
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 4,
+        }}
+      >
+        <span
+          style={{
+            font: "400 13px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            font: "500 13px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface)",
+          }}
+          className="tabular-nums"
+        >
+          {valueText}
+        </span>
+      </div>
+      <Md3Slider
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        ariaLabel={ariaLabel}
+      />
+    </div>
   );
 }

--- a/src/components/practice/AutoBpmControls.tsx
+++ b/src/components/practice/AutoBpmControls.tsx
@@ -1,0 +1,346 @@
+import type { AutoBpmConfig } from "../../hooks/useAutoBpm";
+import type { TabSessionPhase } from "../../types/practice";
+import { Card, Md3Slider } from "../md3";
+
+interface AutoBpmControlsProps {
+  config: AutoBpmConfig;
+  currentBpm: number;
+  startBpm: number;
+  levelUps: number;
+  notification: string | null;
+  phase: TabSessionPhase;
+  onEnabledChange: (enabled: boolean) => void;
+  onThresholdChange: (threshold: number) => void;
+  onIncrementChange: (increment: number) => void;
+  onMaxBpmChange: (maxBpm: number) => void;
+}
+
+export function AutoBpmControls({
+  config,
+  currentBpm,
+  startBpm,
+  levelUps,
+  notification,
+  phase,
+  onEnabledChange,
+  onThresholdChange,
+  onIncrementChange,
+  onMaxBpmChange,
+}: AutoBpmControlsProps) {
+  const active = phase === "playing" || phase === "countdown";
+
+  return (
+    <Card style={{ padding: 20 }}>
+      {/* Header with toggle */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: config.enabled ? 16 : 0,
+        }}
+      >
+        <div
+          style={{
+            font: "500 16px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface)",
+          }}
+        >
+          Auto BPM Up
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={config.enabled}
+          aria-label="Auto BPM Up"
+          disabled={active}
+          onClick={() => onEnabledChange(!config.enabled)}
+          style={{
+            position: "relative",
+            width: 52,
+            height: 32,
+            borderRadius: 16,
+            border: config.enabled
+              ? "none"
+              : "2px solid var(--md-outline)",
+            background: config.enabled
+              ? "var(--md-primary)"
+              : "var(--md-surface-container-highest)",
+            cursor: active ? "not-allowed" : "pointer",
+            opacity: active ? 0.5 : 1,
+            padding: 0,
+            transition: "background 0.2s",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: config.enabled ? 4 : 6,
+              left: config.enabled ? 24 : 6,
+              width: config.enabled ? 24 : 16,
+              height: config.enabled ? 24 : 16,
+              borderRadius: 12,
+              background: config.enabled
+                ? "var(--md-on-primary)"
+                : "var(--md-outline)",
+              transition: "left 0.2s, width 0.2s, height 0.2s, top 0.2s",
+            }}
+          />
+        </button>
+      </div>
+
+      {config.enabled && (
+        <>
+          {/* Notification banner */}
+          {notification && (
+            <div
+              style={{
+                background: "#4ecdc41a",
+                border: "1px solid #4ecdc466",
+                color: "#4ecdc4",
+                borderRadius: 12,
+                padding: "10px 16px",
+                font: "600 14px/1.5 Roboto, sans-serif",
+                textAlign: "center",
+                marginBottom: 16,
+                animation: "fadeIn 0.3s ease-out",
+              }}
+            >
+              {notification}
+            </div>
+          )}
+
+          {/* BPM progress display */}
+          {active && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 12,
+                marginBottom: 16,
+                padding: "12px 0",
+              }}
+            >
+              <div style={{ textAlign: "center" }}>
+                <div
+                  style={{
+                    font: "400 11px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                    marginBottom: 4,
+                  }}
+                >
+                  Start
+                </div>
+                <div
+                  style={{
+                    font: "700 20px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                  className="tabular-nums"
+                >
+                  {startBpm}
+                </div>
+              </div>
+              <div
+                style={{
+                  font: "400 18px/1 Roboto, sans-serif",
+                  color: "var(--md-on-surface-variant)",
+                }}
+              >
+                →
+              </div>
+              <div style={{ textAlign: "center" }}>
+                <div
+                  style={{
+                    font: "400 11px/1 Roboto, sans-serif",
+                    color: "var(--md-primary)",
+                    marginBottom: 4,
+                  }}
+                >
+                  Current
+                </div>
+                <div
+                  style={{
+                    font: "700 24px/1 Roboto, sans-serif",
+                    color: "var(--md-primary)",
+                  }}
+                  className="tabular-nums"
+                >
+                  {currentBpm}
+                </div>
+              </div>
+              <div
+                style={{
+                  font: "400 18px/1 Roboto, sans-serif",
+                  color: "var(--md-on-surface-variant)",
+                }}
+              >
+                →
+              </div>
+              <div style={{ textAlign: "center" }}>
+                <div
+                  style={{
+                    font: "400 11px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                    marginBottom: 4,
+                  }}
+                >
+                  Max
+                </div>
+                <div
+                  style={{
+                    font: "700 20px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                  className="tabular-nums"
+                >
+                  {config.maxBpm}
+                </div>
+              </div>
+              {levelUps > 0 && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    padding: "4px 10px",
+                    borderRadius: 12,
+                    background: "#4ecdc41a",
+                    color: "#4ecdc4",
+                    font: "600 12px/1.5 Roboto, sans-serif",
+                  }}
+                >
+                  +{levelUps}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Settings (disabled while playing) */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 16,
+              opacity: active ? 0.5 : 1,
+              pointerEvents: active ? "none" : "auto",
+            }}
+          >
+            {/* Hit Rate Threshold */}
+            <div>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginBottom: 4,
+                }}
+              >
+                <span
+                  style={{
+                    font: "400 13px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                >
+                  Hit Rate 閾値
+                </span>
+                <span
+                  style={{
+                    font: "500 13px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface)",
+                  }}
+                  className="tabular-nums"
+                >
+                  {Math.round(config.hitRateThreshold * 100)}%
+                </span>
+              </div>
+              <Md3Slider
+                min={50}
+                max={100}
+                step={5}
+                value={Math.round(config.hitRateThreshold * 100)}
+                onChange={(v) => onThresholdChange(v / 100)}
+                disabled={active}
+                ariaLabel="Hit Rate Threshold"
+              />
+            </div>
+
+            {/* BPM Increment */}
+            <div>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginBottom: 4,
+                }}
+              >
+                <span
+                  style={{
+                    font: "400 13px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                >
+                  BPM 増加量
+                </span>
+                <span
+                  style={{
+                    font: "500 13px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface)",
+                  }}
+                  className="tabular-nums"
+                >
+                  +{config.bpmIncrement}
+                </span>
+              </div>
+              <Md3Slider
+                min={1}
+                max={20}
+                step={1}
+                value={config.bpmIncrement}
+                onChange={onIncrementChange}
+                disabled={active}
+                ariaLabel="BPM Increment"
+              />
+            </div>
+
+            {/* Max BPM */}
+            <div>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginBottom: 4,
+                }}
+              >
+                <span
+                  style={{
+                    font: "400 13px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                >
+                  BPM 上限
+                </span>
+                <span
+                  style={{
+                    font: "500 13px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface)",
+                  }}
+                  className="tabular-nums"
+                >
+                  {config.maxBpm}
+                </span>
+              </div>
+              <Md3Slider
+                min={40}
+                max={300}
+                step={5}
+                value={config.maxBpm}
+                onChange={onMaxBpmChange}
+                disabled={active}
+                ariaLabel="Max BPM"
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/components/practice/AutoBpmControls.tsx
+++ b/src/components/practice/AutoBpmControls.tsx
@@ -95,9 +95,11 @@ export function AutoBpmControls({
           {notification && (
             <div
               style={{
-                background: "#4ecdc41a",
-                border: "1px solid #4ecdc466",
-                color: "#4ecdc4",
+                background:
+                  "color-mix(in srgb, var(--md-primary) 10%, transparent)",
+                border:
+                  "1px solid color-mix(in srgb, var(--md-primary) 40%, transparent)",
+                color: "var(--md-primary)",
                 borderRadius: 12,
                 padding: "10px 16px",
                 font: "600 14px/1.5 Roboto, sans-serif",
@@ -204,8 +206,9 @@ export function AutoBpmControls({
                     marginLeft: 8,
                     padding: "4px 10px",
                     borderRadius: 12,
-                    background: "#4ecdc41a",
-                    color: "#4ecdc4",
+                    background:
+                      "color-mix(in srgb, var(--md-primary) 10%, transparent)",
+                    color: "var(--md-primary)",
                     font: "600 12px/1.5 Roboto, sans-serif",
                   }}
                 >

--- a/src/components/practice/AutoBpmControls.tsx
+++ b/src/components/practice/AutoBpmControls.tsx
@@ -29,12 +29,16 @@ export function AutoBpmControls({
   onMaxBpmChange,
 }: AutoBpmControlsProps) {
   const active = phase === "playing" || phase === "countdown";
+  // Allow toggling OFF mid-session (safe: just stops future BPM UPs).
+  // Only lock the toggle when it would turn ON during a live session,
+  // so the user can't enable auto-ramp halfway through a loop.
+  const toggleLocked = active && !config.enabled;
 
   return (
     <Card style={{ padding: 20 }}>
       <Header
         enabled={config.enabled}
-        locked={active}
+        locked={toggleLocked}
         marginBottom={config.enabled ? 16 : 0}
         onToggle={() => onEnabledChange(!config.enabled)}
       />

--- a/src/hooks/useAutoBpm.test.ts
+++ b/src/hooks/useAutoBpm.test.ts
@@ -300,4 +300,24 @@ describe("useAutoBpm", () => {
 
     expect(setBpm).not.toHaveBeenCalled();
   });
+
+  it("does not increase BPM when the loop is all misses (hitRate=0)", () => {
+    // Regression guard: loopEvents is non-empty (misses are still events),
+    // so the early 'empty' return doesn't catch this. The threshold check
+    // must correctly reject a 0% hit rate.
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    const events: TimingEvent[] = [makeMiss(0), makeMiss(1), makeMiss(2)];
+    act(() => {
+      result.current.evaluateLoop(events, 100);
+    });
+
+    expect(setBpm).not.toHaveBeenCalled();
+    expect(result.current.levelUps).toBe(0);
+    expect(result.current.notification).toBeNull();
+  });
 });

--- a/src/hooks/useAutoBpm.test.ts
+++ b/src/hooks/useAutoBpm.test.ts
@@ -44,7 +44,7 @@ describe("useAutoBpm", () => {
     const { result } = renderHook(() => useAutoBpm(100, setBpm));
     const events: TimingEvent[] = [makeHit(0), makeHit(1), makeHit(2)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 100);
     });
     expect(setBpm).not.toHaveBeenCalled();
   });
@@ -59,7 +59,7 @@ describe("useAutoBpm", () => {
     // 100% hit rate, threshold is 90%
     const events: TimingEvent[] = [makeHit(0), makeHit(1), makeHit(2)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 100);
     });
 
     expect(setBpm).toHaveBeenCalledWith(105); // default increment is 5
@@ -77,7 +77,7 @@ describe("useAutoBpm", () => {
     // 50% hit rate < 90% threshold
     const events: TimingEvent[] = [makeHit(0), makeMiss(1)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 100);
     });
 
     expect(setBpm).not.toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe("useAutoBpm", () => {
 
     const events: TimingEvent[] = [makeHit(0), makeHit(1)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 298);
     });
 
     expect(setBpm).toHaveBeenCalledWith(300); // capped at max
@@ -109,7 +109,7 @@ describe("useAutoBpm", () => {
 
     const events: TimingEvent[] = [makeHit(0), makeHit(1)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 300);
     });
 
     expect(setBpm).not.toHaveBeenCalled();
@@ -124,7 +124,7 @@ describe("useAutoBpm", () => {
 
     const events: TimingEvent[] = [makeHit(0), makeHit(1)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 100);
     });
 
     expect(result.current.notification).not.toBeNull();
@@ -145,7 +145,7 @@ describe("useAutoBpm", () => {
 
     const events: TimingEvent[] = [makeHit(0), makeHit(1)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 100);
     });
 
     expect(result.current.levelUps).toBe(1);
@@ -171,10 +171,54 @@ describe("useAutoBpm", () => {
     // 66% hit rate > 50% threshold
     const events: TimingEvent[] = [makeHit(0), makeHit(1), makeMiss(2)];
     act(() => {
-      result.current.evaluateLoop(events);
+      result.current.evaluateLoop(events, 120);
     });
 
     expect(setBpm).toHaveBeenCalledWith(130); // increment of 10
+  });
+
+  it("compounds BPM across consecutive loops using the passed-in currentBpm", () => {
+    // Regression: evaluateLoop must rely on the caller-supplied currentBpm,
+    // not on a stale value closed over at hook render time. Two back-to-back
+    // loops (without any re-render between them) should both increase BPM.
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    const events: TimingEvent[] = [makeHit(0), makeHit(1)];
+    act(() => {
+      result.current.evaluateLoop(events, 100);
+      // Simulate the caller reading the fresh BPM from a ref on the next
+      // loop boundary, before React has flushed the previous setBpm.
+      result.current.evaluateLoop(events, 105);
+    });
+
+    expect(setBpm).toHaveBeenNthCalledWith(1, 105);
+    expect(setBpm).toHaveBeenNthCalledWith(2, 110);
+    expect(result.current.levelUps).toBe(2);
+  });
+
+  it("clears pending notification timer on unmount", () => {
+    const { result, unmount } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    const events: TimingEvent[] = [makeHit(0), makeHit(1)];
+    act(() => {
+      result.current.evaluateLoop(events, 100);
+    });
+    expect(result.current.notification).not.toBeNull();
+
+    unmount();
+    // Advancing past the notification timeout must not throw or cause
+    // a state update on an unmounted component.
+    expect(() => {
+      vi.advanceTimersByTime(5000);
+    }).not.toThrow();
   });
 
   it("ignores empty loop events", () => {
@@ -185,7 +229,7 @@ describe("useAutoBpm", () => {
     });
 
     act(() => {
-      result.current.evaluateLoop([]);
+      result.current.evaluateLoop([], 100);
     });
 
     expect(setBpm).not.toHaveBeenCalled();

--- a/src/hooks/useAutoBpm.test.ts
+++ b/src/hooks/useAutoBpm.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAutoBpm } from "./useAutoBpm";
+import type { TimingEvent, HitTimingEvent, MissTimingEvent } from "../types/practice";
+
+function makeHit(beat: number, deltaMs = 10): HitTimingEvent {
+  return {
+    targetBeat: beat,
+    targetTimeMs: beat * 500,
+    onsetTimeMs: beat * 500 + deltaMs,
+    deltaMs,
+    judgment: "hit",
+  };
+}
+
+function makeMiss(beat: number): MissTimingEvent {
+  return {
+    targetBeat: beat,
+    targetTimeMs: beat * 500,
+    onsetTimeMs: null,
+    deltaMs: null,
+    judgment: "miss",
+  };
+}
+
+describe("useAutoBpm", () => {
+  let setBpm: (bpm: number) => void;
+
+  beforeEach(() => {
+    setBpm = vi.fn();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts disabled by default", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+    expect(result.current.config.enabled).toBe(false);
+  });
+
+  it("does not increase BPM when disabled", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+    const events: TimingEvent[] = [makeHit(0), makeHit(1), makeHit(2)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+    expect(setBpm).not.toHaveBeenCalled();
+  });
+
+  it("increases BPM when hit rate exceeds threshold", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    // 100% hit rate, threshold is 90%
+    const events: TimingEvent[] = [makeHit(0), makeHit(1), makeHit(2)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(setBpm).toHaveBeenCalledWith(105); // default increment is 5
+    expect(result.current.levelUps).toBe(1);
+    expect(result.current.notification).toContain("BPM UP");
+  });
+
+  it("does not increase BPM when hit rate is below threshold", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    // 50% hit rate < 90% threshold
+    const events: TimingEvent[] = [makeHit(0), makeMiss(1)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(setBpm).not.toHaveBeenCalled();
+  });
+
+  it("respects maxBpm", () => {
+    const { result } = renderHook(() => useAutoBpm(298, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+      result.current.setMaxBpm(300);
+    });
+
+    const events: TimingEvent[] = [makeHit(0), makeHit(1)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(setBpm).toHaveBeenCalledWith(300); // capped at max
+  });
+
+  it("does not increase past maxBpm", () => {
+    const { result } = renderHook(() => useAutoBpm(300, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+      result.current.setMaxBpm(300);
+    });
+
+    const events: TimingEvent[] = [makeHit(0), makeHit(1)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(setBpm).not.toHaveBeenCalled();
+  });
+
+  it("clears notification after timeout", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    const events: TimingEvent[] = [makeHit(0), makeHit(1)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(result.current.notification).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.notification).toBeNull();
+  });
+
+  it("resets session state", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    const events: TimingEvent[] = [makeHit(0), makeHit(1)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(result.current.levelUps).toBe(1);
+
+    act(() => {
+      result.current.resetSession(80);
+    });
+
+    expect(result.current.levelUps).toBe(0);
+    expect(result.current.startBpm).toBe(80);
+    expect(result.current.notification).toBeNull();
+  });
+
+  it("respects custom threshold and increment", () => {
+    const { result } = renderHook(() => useAutoBpm(120, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+      result.current.setHitRateThreshold(0.5);
+      result.current.setBpmIncrement(10);
+    });
+
+    // 66% hit rate > 50% threshold
+    const events: TimingEvent[] = [makeHit(0), makeHit(1), makeMiss(2)];
+    act(() => {
+      result.current.evaluateLoop(events);
+    });
+
+    expect(setBpm).toHaveBeenCalledWith(130); // increment of 10
+  });
+
+  it("ignores empty loop events", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    act(() => {
+      result.current.evaluateLoop([]);
+    });
+
+    expect(setBpm).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAutoBpm.test.ts
+++ b/src/hooks/useAutoBpm.test.ts
@@ -29,10 +29,12 @@ describe("useAutoBpm", () => {
   beforeEach(() => {
     setBpm = vi.fn();
     vi.useFakeTimers();
+    window.localStorage.removeItem("bass-practice.autoBpmConfig");
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    window.localStorage.removeItem("bass-practice.autoBpmConfig");
   });
 
   it("starts disabled by default", () => {
@@ -219,6 +221,70 @@ describe("useAutoBpm", () => {
     expect(() => {
       vi.advanceTimersByTime(5000);
     }).not.toThrow();
+  });
+
+  it("persists config changes to localStorage (excluding enabled)", () => {
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+
+    act(() => {
+      result.current.setEnabled(true);
+      result.current.setHitRateThreshold(0.75);
+      result.current.setBpmIncrement(7);
+      result.current.setMaxBpm(250);
+    });
+
+    const stored = JSON.parse(
+      window.localStorage.getItem("bass-practice.autoBpmConfig")!,
+    );
+    expect(stored).toEqual({
+      hitRateThreshold: 0.75,
+      bpmIncrement: 7,
+      maxBpm: 250,
+    });
+    expect(stored.enabled).toBeUndefined();
+  });
+
+  it("restores persisted config on next mount with enabled=false", () => {
+    window.localStorage.setItem(
+      "bass-practice.autoBpmConfig",
+      JSON.stringify({
+        hitRateThreshold: 0.6,
+        bpmIncrement: 8,
+        maxBpm: 180,
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+    expect(result.current.config).toEqual({
+      enabled: false,
+      hitRateThreshold: 0.6,
+      bpmIncrement: 8,
+      maxBpm: 180,
+    });
+  });
+
+  it("falls back to defaults when localStorage has invalid JSON", () => {
+    window.localStorage.setItem("bass-practice.autoBpmConfig", "not json {{");
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+    expect(result.current.config.hitRateThreshold).toBe(0.9);
+    expect(result.current.config.bpmIncrement).toBe(5);
+    expect(result.current.config.maxBpm).toBe(200);
+  });
+
+  it("ignores out-of-range persisted values", () => {
+    window.localStorage.setItem(
+      "bass-practice.autoBpmConfig",
+      JSON.stringify({
+        hitRateThreshold: 2, // invalid > 1
+        bpmIncrement: -1, // invalid
+        maxBpm: 0, // invalid
+      }),
+    );
+    const { result } = renderHook(() => useAutoBpm(100, setBpm));
+    // Each invalid field falls back to its default individually.
+    expect(result.current.config.hitRateThreshold).toBe(0.9);
+    expect(result.current.config.bpmIncrement).toBe(5);
+    expect(result.current.config.maxBpm).toBe(200);
   });
 
   it("ignores empty loop events", () => {

--- a/src/hooks/useAutoBpm.ts
+++ b/src/hooks/useAutoBpm.ts
@@ -27,9 +27,56 @@ const DEFAULT_CONFIG: AutoBpmConfig = {
 };
 
 const NOTIFICATION_DURATION_MS = 2500;
+const STORAGE_KEY = "bass-practice.autoBpmConfig";
+
+/** Persisted fields. `enabled` is intentionally NOT persisted: every
+ * session starts with the toggle OFF so the user opts in explicitly. */
+type PersistedConfig = Pick<
+  AutoBpmConfig,
+  "hitRateThreshold" | "bpmIncrement" | "maxBpm"
+>;
+
+function loadPersistedConfig(): AutoBpmConfig {
+  if (typeof window === "undefined") return DEFAULT_CONFIG;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_CONFIG;
+    const parsed = JSON.parse(raw) as Partial<PersistedConfig>;
+    return {
+      ...DEFAULT_CONFIG,
+      ...(typeof parsed.hitRateThreshold === "number" &&
+      parsed.hitRateThreshold >= 0 &&
+      parsed.hitRateThreshold <= 1
+        ? { hitRateThreshold: parsed.hitRateThreshold }
+        : {}),
+      ...(typeof parsed.bpmIncrement === "number" && parsed.bpmIncrement > 0
+        ? { bpmIncrement: parsed.bpmIncrement }
+        : {}),
+      ...(typeof parsed.maxBpm === "number" && parsed.maxBpm > 0
+        ? { maxBpm: parsed.maxBpm }
+        : {}),
+    };
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+function persistConfig(config: AutoBpmConfig) {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: PersistedConfig = {
+      hitRateThreshold: config.hitRateThreshold,
+      bpmIncrement: config.bpmIncrement,
+      maxBpm: config.maxBpm,
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* quota/private-mode: silently ignore */
+  }
+}
 
 export function useAutoBpm(initialBpm: number, setBpm: (bpm: number) => void) {
-  const [config, setConfig] = useState<AutoBpmConfig>(DEFAULT_CONFIG);
+  const [config, setConfig] = useState<AutoBpmConfig>(loadPersistedConfig);
   const [levelUps, setLevelUps] = useState(0);
   const [notification, setNotification] = useState<string | null>(null);
   const [startBpm, setStartBpm] = useState(initialBpm);
@@ -41,6 +88,7 @@ export function useAutoBpm(initialBpm: number, setBpm: (bpm: number) => void) {
   const configRef = useRef(config);
   useEffect(() => {
     configRef.current = config;
+    persistConfig(config);
   }, [config]);
   const setBpmRef = useRef(setBpm);
   useEffect(() => {

--- a/src/hooks/useAutoBpm.ts
+++ b/src/hooks/useAutoBpm.ts
@@ -1,0 +1,117 @@
+import { useState, useCallback, useRef, useMemo } from "react";
+import type { TimingEvent } from "../types/practice";
+import { computeStats } from "../lib/practice/timingEvaluator";
+
+export interface AutoBpmConfig {
+  enabled: boolean;
+  hitRateThreshold: number; // 0-1, default 0.9
+  bpmIncrement: number; // default 5
+  maxBpm: number; // default 200
+}
+
+export interface AutoBpmState {
+  config: AutoBpmConfig;
+  /** The BPM we started from (before any auto-ups) */
+  startBpm: number;
+  /** Number of times BPM was auto-increased this session */
+  levelUps: number;
+  /** The notification message shown briefly when BPM increases */
+  notification: string | null;
+}
+
+const DEFAULT_CONFIG: AutoBpmConfig = {
+  enabled: false,
+  hitRateThreshold: 0.9,
+  bpmIncrement: 5,
+  maxBpm: 200,
+};
+
+export function useAutoBpm(currentBpm: number, setBpm: (bpm: number) => void) {
+  const [config, setConfig] = useState<AutoBpmConfig>(DEFAULT_CONFIG);
+  const [levelUps, setLevelUps] = useState(0);
+  const [notification, setNotification] = useState<string | null>(null);
+  const [startBpm, setStartBpm] = useState(currentBpm);
+  const notificationTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const setEnabled = useCallback((enabled: boolean) => {
+    setConfig((prev) => ({ ...prev, enabled }));
+  }, []);
+
+  const setHitRateThreshold = useCallback((hitRateThreshold: number) => {
+    setConfig((prev) => ({ ...prev, hitRateThreshold }));
+  }, []);
+
+  const setBpmIncrement = useCallback((bpmIncrement: number) => {
+    setConfig((prev) => ({ ...prev, bpmIncrement }));
+  }, []);
+
+  const setMaxBpm = useCallback((maxBpm: number) => {
+    setConfig((prev) => ({ ...prev, maxBpm }));
+  }, []);
+
+  /**
+   * Called at the end of each loop with that loop's timing events.
+   * Returns the new BPM if it was increased, or null.
+   */
+  const evaluateLoop = useCallback(
+    (loopEvents: TimingEvent[]): number | null => {
+      if (!config.enabled || loopEvents.length === 0) return null;
+
+      const stats = computeStats(loopEvents);
+      if (stats.hitRate < config.hitRateThreshold) return null;
+
+      const newBpm = Math.min(
+        currentBpm + config.bpmIncrement,
+        config.maxBpm,
+      );
+      if (newBpm <= currentBpm) return null; // already at max
+
+      setBpm(newBpm);
+      setLevelUps((prev) => prev + 1);
+
+      const msg = `🎯 BPM UP! ${currentBpm} → ${newBpm}`;
+      setNotification(msg);
+      clearTimeout(notificationTimerRef.current);
+      notificationTimerRef.current = setTimeout(() => {
+        setNotification(null);
+      }, 2500);
+
+      return newBpm;
+    },
+    [config, currentBpm, setBpm],
+  );
+
+  const resetSession = useCallback((bpm: number) => {
+    setStartBpm(bpm);
+    setLevelUps(0);
+    setNotification(null);
+    clearTimeout(notificationTimerRef.current);
+  }, []);
+
+  return useMemo(
+    () => ({
+      config,
+      startBpm,
+      levelUps,
+      notification,
+      setEnabled,
+      setHitRateThreshold,
+      setBpmIncrement,
+      setMaxBpm,
+      evaluateLoop,
+      resetSession,
+    }),
+    [
+      config,
+      startBpm,
+      levelUps,
+      notification,
+      setEnabled,
+      setHitRateThreshold,
+      setBpmIncrement,
+      setMaxBpm,
+      evaluateLoop,
+      resetSession,
+    ],
+  );
+}

--- a/src/hooks/useAutoBpm.ts
+++ b/src/hooks/useAutoBpm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import type { TimingEvent } from "../types/practice";
 import { computeStats } from "../lib/practice/timingEvaluator";
 
@@ -26,12 +26,34 @@ const DEFAULT_CONFIG: AutoBpmConfig = {
   maxBpm: 200,
 };
 
-export function useAutoBpm(currentBpm: number, setBpm: (bpm: number) => void) {
+const NOTIFICATION_DURATION_MS = 2500;
+
+export function useAutoBpm(initialBpm: number, setBpm: (bpm: number) => void) {
   const [config, setConfig] = useState<AutoBpmConfig>(DEFAULT_CONFIG);
   const [levelUps, setLevelUps] = useState(0);
   const [notification, setNotification] = useState<string | null>(null);
-  const [startBpm, setStartBpm] = useState(currentBpm);
+  const [startBpm, setStartBpm] = useState(initialBpm);
   const notificationTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Mirror config + setBpm into refs so `evaluateLoop` stays referentially
+  // stable across renders. This avoids cascading effect re-runs in the
+  // caller (useTabPractice wraps the hook's return in an autoBpmRef).
+  const configRef = useRef(config);
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
+  const setBpmRef = useRef(setBpm);
+  useEffect(() => {
+    setBpmRef.current = setBpm;
+  }, [setBpm]);
+
+  // Clean up pending notification timer on unmount to avoid setting state
+  // on an unmounted component (e.g. navigating away right after a BPM UP).
+  useEffect(() => {
+    return () => {
+      clearTimeout(notificationTimerRef.current);
+    };
+  }, []);
 
   const setEnabled = useCallback((enabled: boolean) => {
     setConfig((prev) => ({ ...prev, enabled }));
@@ -50,35 +72,35 @@ export function useAutoBpm(currentBpm: number, setBpm: (bpm: number) => void) {
   }, []);
 
   /**
-   * Called at the end of each loop with that loop's timing events.
+   * Called at the end of each loop with that loop's timing events and the
+   * freshly-observed BPM. The caller MUST pass `currentBpm` from a ref so
+   * consecutive loop boundaries always see the latest value (state updates
+   * from a previous BPM UP may not have propagated through the hook yet).
    * Returns the new BPM if it was increased, or null.
    */
   const evaluateLoop = useCallback(
-    (loopEvents: TimingEvent[]): number | null => {
-      if (!config.enabled || loopEvents.length === 0) return null;
+    (loopEvents: TimingEvent[], currentBpm: number): number | null => {
+      const cfg = configRef.current;
+      if (!cfg.enabled || loopEvents.length === 0) return null;
 
       const stats = computeStats(loopEvents);
-      if (stats.hitRate < config.hitRateThreshold) return null;
+      if (stats.hitRate < cfg.hitRateThreshold) return null;
 
-      const newBpm = Math.min(
-        currentBpm + config.bpmIncrement,
-        config.maxBpm,
-      );
+      const newBpm = Math.min(currentBpm + cfg.bpmIncrement, cfg.maxBpm);
       if (newBpm <= currentBpm) return null; // already at max
 
-      setBpm(newBpm);
+      setBpmRef.current(newBpm);
       setLevelUps((prev) => prev + 1);
 
-      const msg = `🎯 BPM UP! ${currentBpm} → ${newBpm}`;
-      setNotification(msg);
+      setNotification(`🎯 BPM UP! ${currentBpm} → ${newBpm}`);
       clearTimeout(notificationTimerRef.current);
       notificationTimerRef.current = setTimeout(() => {
         setNotification(null);
-      }, 2500);
+      }, NOTIFICATION_DURATION_MS);
 
       return newBpm;
     },
-    [config, currentBpm, setBpm],
+    [],
   );
 
   const resetSession = useCallback((bpm: number) => {

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/practice/timingEvaluator";
 import type { TimingTarget } from "../lib/practice/timingEvaluator";
 import { useMetronome } from "./useMetronome";
+import { useAutoBpm } from "./useAutoBpm";
 
 export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | null) {
   const metronome = useMetronome(
@@ -17,6 +18,12 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
     preset.timeSignature.beatsPerMeasure,
     preset.timeSignature.beatUnit,
   );
+
+  const autoBpm = useAutoBpm(metronome.bpm, metronome.setBpm);
+  const autoBpmRef = useRef(autoBpm);
+  useEffect(() => {
+    autoBpmRef.current = autoBpm;
+  }, [autoBpm]);
 
   // Ref keeps the latest metronome value so callbacks/effects can access it
   // without depending on the metronome object identity (which triggers
@@ -37,6 +44,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
   const hitBeatsRef = useRef(new Set<number>());
   const animFrameRef = useRef(0);
   const allEventsRef = useRef<TimingEvent[]>([]);
+  const loopEventsRef = useRef<TimingEvent[]>([]);
   const phaseRef = useRef<TabSessionPhase>("idle");
 
   useEffect(() => {
@@ -74,6 +82,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
         if (event) {
           hitBeatsRef.current.add(event.targetBeat);
           allEventsRef.current = [...allEventsRef.current, event];
+          loopEventsRef.current = [...loopEventsRef.current, event];
           setTimingEvents((prev) => [...prev, event]);
           setLastEvent(event);
         }
@@ -106,8 +115,14 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
           const misses = generateMisses(targetsRef.current, hitBeatsRef.current);
           if (misses.length > 0) {
             allEventsRef.current = [...allEventsRef.current, ...misses];
+            loopEventsRef.current = [...loopEventsRef.current, ...misses];
             setTimingEvents((prev) => [...prev, ...misses]);
           }
+
+          // Evaluate auto-BPM at loop boundary
+          autoBpmRef.current.evaluateLoop(loopEventsRef.current);
+          loopEventsRef.current = [];
+
           setLoop((prev) => prev + 1);
         }
         hitBeatsRef.current = new Set();
@@ -132,9 +147,11 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
     setLoop(0);
     setLastEvent(null);
     allEventsRef.current = [];
+    loopEventsRef.current = [];
     hitBeatsRef.current = new Set();
     targetsRef.current = [];
     onsetDetectorRef.current.reset();
+    autoBpmRef.current.resetSession(metronomeRef.current.bpm);
 
     // Prepare AudioContext synchronously inside the click handler's
     // call-stack so the browser unlocks audio output before the async gap.
@@ -192,9 +209,10 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
       lastEvent,
       stats,
       metronome: metronomeSlice,
+      autoBpm,
       startSession,
       stopSession,
     }),
-    [phase, currentBeat, loop, timingEvents, lastEvent, stats, metronomeSlice, startSession, stopSession],
+    [phase, currentBeat, loop, timingEvents, lastEvent, stats, metronomeSlice, autoBpm, startSession, stopSession],
   );
 }

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -119,8 +119,13 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
             setTimingEvents((prev) => [...prev, ...misses]);
           }
 
-          // Evaluate auto-BPM at loop boundary
-          autoBpmRef.current.evaluateLoop(loopEventsRef.current);
+          // Evaluate auto-BPM at loop boundary. Pass the freshly-observed
+          // BPM from the ref, not a closed-over state value, so consecutive
+          // BPM UPs compound correctly across loops.
+          autoBpmRef.current.evaluateLoop(
+            loopEventsRef.current,
+            metronomeRef.current.bpm,
+          );
           loopEventsRef.current = [];
 
           setLoop((prev) => prev + 1);

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -5,6 +5,7 @@ import { useAudioInput } from "../hooks/useAudioInput";
 import { useTabPractice } from "../hooks/useTabPractice";
 import { AsciiTabDisplay } from "../components/practice/AsciiTabDisplay";
 import { MetronomeControls } from "../components/practice/MetronomeControls";
+import { AutoBpmControls } from "../components/practice/AutoBpmControls";
 import { TimingFeedback } from "../components/practice/TimingFeedback";
 import { Tag } from "../components/md3";
 import { useMediaQuery } from "../hooks/useMediaQuery";
@@ -68,6 +69,21 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
 
   const displayedError = startError;
   const micWarning = !startError && audio.error ? audio.error : null;
+
+  const autoBpmBlock = (
+    <AutoBpmControls
+      config={practice.autoBpm.config}
+      currentBpm={practice.metronome.bpm}
+      startBpm={practice.autoBpm.startBpm}
+      levelUps={practice.autoBpm.levelUps}
+      notification={practice.autoBpm.notification}
+      phase={practice.phase}
+      onEnabledChange={practice.autoBpm.setEnabled}
+      onThresholdChange={practice.autoBpm.setHitRateThreshold}
+      onIncrementChange={practice.autoBpm.setBpmIncrement}
+      onMaxBpmChange={practice.autoBpm.setMaxBpm}
+    />
+  );
 
   const errorBlock = (
     <>
@@ -165,6 +181,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
               onStart={handleStart}
               onStop={practice.stopSession}
             />
+            {autoBpmBlock}
             {errorBlock}
           </div>
           <TimingFeedback
@@ -185,6 +202,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
             onStart={handleStart}
             onStop={practice.stopSession}
           />
+          {autoBpmBlock}
           {errorBlock}
           <TimingFeedback
             lastEvent={practice.lastEvent}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,3 +11,27 @@ vi.stubGlobal("cancelAnimationFrame", vi.fn());
 afterEach(() => {
   cleanup();
 });
+
+// jsdom's default localStorage is not functional under the current
+// vitest config; provide a minimal in-memory implementation so hooks
+// that persist settings can be tested deterministically.
+const memStore = new Map<string, string>();
+const memLocalStorage: Storage = {
+  get length() {
+    return memStore.size;
+  },
+  clear: () => memStore.clear(),
+  getItem: (k) => (memStore.has(k) ? memStore.get(k)! : null),
+  setItem: (k, v) => {
+    memStore.set(k, String(v));
+  },
+  removeItem: (k) => {
+    memStore.delete(k);
+  },
+  key: (i) => Array.from(memStore.keys())[i] ?? null,
+};
+vi.stubGlobal("localStorage", memLocalStorage);
+Object.defineProperty(window, "localStorage", {
+  configurable: true,
+  value: memLocalStorage,
+});


### PR DESCRIPTION
## 概要
Issue #42 の実装。タブ譜練習でループ終了時にhit率を評価し、閾値を超えたら自動でBPMを上げる機能。

## 変更内容

### 新規ファイル
- `src/hooks/useAutoBpm.ts` — Auto BPMロジックのカスタムフック
- `src/hooks/useAutoBpm.test.ts` — ユニットテスト10件
- `src/components/practice/AutoBpmControls.tsx` — 設定UI（MD3スタイル）

### 変更ファイル
- `src/hooks/useTabPractice.ts` — ループ境界でevaluateLoop呼び出し
- `src/pages/TabPracticePage.tsx` — AutoBpmControlsの配置（desktop/mobile両対応）

## 実装した要件
- [x] hit率の閾値を設定可能（デフォルト: 90%）
- [x] 閾値を超えたら自動で BPM を上げる（デフォルト: +5 BPM）
- [x] BPM上限の設定（デフォルト: 200）
- [x] 現在のBPMと目標BPMの表示（Start → Current → Max）
- [x] 自動アップのON/OFF切り替え（トグルスイッチ）
- [x] BPMが上がった瞬間のフィードバック（🎯 BPM UP! バナー、2.5秒で消去）

## 動作仕様
1. Auto BPM UpをONにして練習開始
2. 各ループ終了時にそのループのhit率を計算
3. hit率が閾値以上 → BPMを増加量分アップ（上限まで）
4. BPM UP時に視覚的通知を表示
5. セッション開始時にlevelUps/startBpmをリセット

## テスト
- 全170テスト通過（新規10件含む）
- `npm run build` / `npm run lint` クリーン

Closes #42