### PR TITLE
feat: カスタムタブ譜エディタ (#43)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from "./components/Layout";
 import { HomePage } from "./pages/HomePage";
 import { TunerPage } from "./pages/TunerPage";
 import { TabPracticePage } from "./pages/TabPracticePage";
+import { EditorPage } from "./pages/EditorPage";
 
 function App() {
   return (
@@ -11,6 +12,8 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/tuner" element={<TunerPage />} />
         <Route path="/practice/tab/:presetId" element={<TabPracticePage />} />
+        <Route path="/editor" element={<EditorPage />} />
+        <Route path="/editor/:id" element={<EditorPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
 import { tabPresets } from "../data/tabPresets";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { useCustomTabs } from "../hooks/useCustomTabs";
 
 export function Layout() {
   const location = useLocation();
@@ -8,18 +9,26 @@ export function Layout() {
   const params = useParams();
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
+  const { tabs: customTabs } = useCustomTabs();
   const isPractice = location.pathname.startsWith("/practice/tab/");
+  const isEditor = location.pathname.startsWith("/editor");
   const practicePreset = isPractice
-    ? tabPresets.find((p) => p.id === params.presetId)
+    ? (tabPresets.find((p) => p.id === params.presetId) ??
+      customTabs.find((p) => p.id === params.presetId))
     : undefined;
 
   const title = isPractice
     ? (practicePreset?.name ?? "練習")
-    : location.pathname === "/tuner"
-      ? "チューナー"
-      : "Bass Practice";
+    : isEditor
+      ? (params.id
+          ? (customTabs.find((t) => t.id === params.id)?.name ?? "タブ譜を編集")
+          : "タブ譜を作る")
+      : location.pathname === "/tuner"
+        ? "チューナー"
+        : "Bass Practice";
 
   const currentTab = location.pathname === "/tuner" ? "tuner" : "home";
+  const hideNav = isPractice || isEditor;
 
   return (
     <div
@@ -31,7 +40,7 @@ export function Layout() {
         background: "var(--md-background)",
       }}
     >
-      {isDesktop && !isPractice && (
+      {isDesktop && !hideNav && (
         <SideNav
           current={currentTab}
           onChange={(id) => navigate(id === "home" ? "/" : "/tuner")}
@@ -51,7 +60,7 @@ export function Layout() {
       >
         <TopAppBar
           title={title}
-          onBack={isPractice ? () => navigate("/") : undefined}
+          onBack={hideNav ? () => navigate("/") : undefined}
         />
 
         <main
@@ -62,7 +71,7 @@ export function Layout() {
           <Outlet />
         </main>
 
-        {!isPractice && !isDesktop && (
+        {!hideNav && !isDesktop && (
           <BottomNav
             current={currentTab}
             onChange={(id) => navigate(id === "home" ? "/" : "/tuner")}

--- a/src/components/editor/TabGrid.tsx
+++ b/src/components/editor/TabGrid.tsx
@@ -1,0 +1,178 @@
+import { Fragment, useState } from "react";
+import type { TabNote, TabPreset } from "../../types/practice";
+import { Card } from "../md3";
+
+interface TabGridProps {
+  preset: TabPreset;
+  onNotesChange: (notes: TabNote[]) => void;
+}
+
+const STRING_LABELS = ["G", "D", "A", "E"]; // string 1..4
+const MAX_FRET = 24;
+
+export function TabGrid({ preset, onNotesChange }: TabGridProps) {
+  const [selectedFret, setSelectedFret] = useState<number>(0);
+  const totalBeats = preset.timeSignature.beatsPerMeasure * preset.measures;
+  const beatsPerMeasure = preset.timeSignature.beatsPerMeasure;
+
+  const cellAt = (stringNum: number, beat: number): TabNote | undefined =>
+    preset.notes.find((n) => n.string === stringNum && n.beat === beat);
+
+  const handleCellClick = (stringNum: number, beat: number) => {
+    const existing = cellAt(stringNum, beat);
+    if (existing && existing.fret === selectedFret) {
+      onNotesChange(preset.notes.filter((n) => n !== existing));
+    } else if (existing) {
+      onNotesChange(
+        preset.notes.map((n) =>
+          n === existing ? { ...n, fret: selectedFret } : n,
+        ),
+      );
+    } else {
+      onNotesChange([
+        ...preset.notes,
+        { string: stringNum, fret: selectedFret, beat },
+      ]);
+    }
+  };
+
+  const cellW = 40;
+  const labelW = 28;
+
+  return (
+    <Card style={{ padding: 16, display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Fret picker */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <label
+          style={{
+            font: "500 11px/1 Roboto, sans-serif",
+            letterSpacing: 1.2,
+            textTransform: "uppercase",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          フレット選択（セルタップで配置 / 同じセル再タップで削除）
+        </label>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+          {Array.from({ length: MAX_FRET + 1 }, (_, i) => {
+            const active = i === selectedFret;
+            return (
+              <button
+                key={i}
+                onClick={() => setSelectedFret(i)}
+                aria-pressed={active}
+                style={{
+                  minWidth: 32,
+                  height: 32,
+                  borderRadius: 8,
+                  border: active
+                    ? "2px solid var(--md-primary)"
+                    : "1px solid var(--md-outline-variant)",
+                  background: active
+                    ? "var(--md-primary-container)"
+                    : "var(--md-surface-container)",
+                  color: active
+                    ? "var(--md-on-primary-container)"
+                    : "var(--md-on-surface)",
+                  font: "500 13px/1 Roboto, sans-serif",
+                  cursor: "pointer",
+                }}
+              >
+                {i}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div style={{ overflowX: "auto" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: `${labelW}px repeat(${totalBeats}, ${cellW}px)`,
+            gap: 2,
+            minWidth: labelW + totalBeats * (cellW + 2),
+          }}
+        >
+          {/* Header row: beat numbers */}
+          <div />
+          {Array.from({ length: totalBeats }, (_, beat) => {
+            const measureIdx = Math.floor(beat / beatsPerMeasure);
+            const beatInMeasure = (beat % beatsPerMeasure) + 1;
+            const isDownbeat = beat % beatsPerMeasure === 0;
+            return (
+              <div
+                key={`h-${beat}`}
+                style={{
+                  textAlign: "center",
+                  font: "500 10px/1.3 Roboto, sans-serif",
+                  color: "var(--md-on-surface-variant)",
+                  paddingBottom: 4,
+                  borderLeft: isDownbeat
+                    ? "2px solid var(--md-outline)"
+                    : "none",
+                }}
+              >
+                {isDownbeat && (
+                  <div style={{ color: "var(--md-primary)", fontWeight: 600 }}>
+                    M{measureIdx + 1}
+                  </div>
+                )}
+                <div>{beatInMeasure}</div>
+              </div>
+            );
+          })}
+
+          {/* String rows */}
+          {STRING_LABELS.map((label, i) => {
+            const stringNum = i + 1;
+            return (
+              <Fragment key={`row-${stringNum}`}>
+                <div
+                  key={`l-${stringNum}`}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    font: "600 14px/1 Roboto, sans-serif",
+                    color: "var(--md-on-surface-variant)",
+                  }}
+                >
+                  {label}
+                </div>
+                {Array.from({ length: totalBeats }, (_, beat) => {
+                  const note = cellAt(stringNum, beat);
+                  const isDownbeat = beat % beatsPerMeasure === 0;
+                  return (
+                    <button
+                      key={`c-${stringNum}-${beat}`}
+                      onClick={() => handleCellClick(stringNum, beat)}
+                      style={{
+                        height: 36,
+                        borderRadius: 6,
+                        border: isDownbeat
+                          ? "1px solid var(--md-outline)"
+                          : "1px solid var(--md-outline-variant)",
+                        background: note
+                          ? "var(--md-primary)"
+                          : "var(--md-surface-container-low)",
+                        color: note
+                          ? "var(--md-on-primary)"
+                          : "var(--md-on-surface-variant)",
+                        font: "500 13px/1 Roboto, sans-serif",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {note ? note.fret : ""}
+                    </button>
+                  );
+                })}
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/editor/TabGrid.tsx
+++ b/src/components/editor/TabGrid.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState } from "react";
 import type { TabNote, TabPreset } from "../../types/practice";
+import { toggleNote } from "../../lib/customTabs";
 import { Card } from "../md3";
 
 interface TabGridProps {
@@ -19,21 +20,7 @@ export function TabGrid({ preset, onNotesChange }: TabGridProps) {
     preset.notes.find((n) => n.string === stringNum && n.beat === beat);
 
   const handleCellClick = (stringNum: number, beat: number) => {
-    const existing = cellAt(stringNum, beat);
-    if (existing && existing.fret === selectedFret) {
-      onNotesChange(preset.notes.filter((n) => n !== existing));
-    } else if (existing) {
-      onNotesChange(
-        preset.notes.map((n) =>
-          n === existing ? { ...n, fret: selectedFret } : n,
-        ),
-      );
-    } else {
-      onNotesChange([
-        ...preset.notes,
-        { string: stringNum, fret: selectedFret, beat },
-      ]);
-    }
+    onNotesChange(toggleNote(preset.notes, stringNum, beat, selectedFret));
   };
 
   const cellW = 40;

--- a/src/components/practice/CustomTabCard.tsx
+++ b/src/components/practice/CustomTabCard.tsx
@@ -1,0 +1,118 @@
+import { useState, type CSSProperties } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import type { TabPreset } from "../../types/practice";
+import { Tag } from "../md3";
+
+interface CustomTabCardProps {
+  preset: TabPreset;
+  onDelete: () => void;
+}
+
+export function CustomTabCard({ preset, onDelete }: CustomTabCardProps) {
+  const [hovered, setHovered] = useState(false);
+  const navigate = useNavigate();
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: hovered
+          ? "var(--md-surface-container-highest)"
+          : "var(--md-surface-container-high)",
+        borderRadius: 16,
+        padding: "20px 20px 16px",
+        transition: "background 0.15s",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        color: "var(--md-on-surface)",
+        position: "relative",
+      }}
+    >
+      <Link
+        to={`/practice/tab/${preset.id}`}
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: 16,
+          textDecoration: "none",
+        }}
+        aria-label={`${preset.name} で練習`}
+      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            font: "500 18px/1.2 Roboto, sans-serif",
+            color: hovered ? "var(--md-primary)" : "var(--md-on-surface)",
+          }}
+        >
+          {preset.name || "(無題)"}
+        </h3>
+        <Tag label="マイタブ譜" style={{ background: "var(--md-tertiary-container, #4a4458)", color: "var(--md-on-tertiary-container, #eaddff)" }} />
+      </div>
+
+      {preset.description && (
+        <p
+          style={{
+            margin: 0,
+            font: "400 14px/1.5 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          {preset.description}
+        </p>
+      )}
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+        <Tag label={`${preset.bpm} BPM`} />
+        <Tag
+          label={`${preset.timeSignature.beatsPerMeasure}/${preset.timeSignature.beatUnit}`}
+        />
+        <Tag label={`${preset.measures} 小節`} />
+        <Tag label={`${preset.notes.length} ノート`} />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          marginTop: 8,
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        <button
+          onClick={() => navigate(`/editor/${preset.id}`)}
+          style={btnStyle}
+        >
+          ✏️ 編集
+        </button>
+        <button
+          onClick={onDelete}
+          style={{ ...btnStyle, color: "#ef5350" }}
+        >
+          🗑️ 削除
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const btnStyle: CSSProperties = {
+  background: "transparent",
+  border: "1px solid var(--md-outline-variant)",
+  color: "var(--md-on-surface)",
+  padding: "6px 12px",
+  borderRadius: 16,
+  font: "500 12px/1 Roboto, sans-serif",
+  cursor: "pointer",
+};

--- a/src/components/practice/PresetCard.tsx
+++ b/src/components/practice/PresetCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import type { TabPreset } from "../../types/practice";
 import { Tag } from "../md3";
 
@@ -21,6 +21,7 @@ const DIFFICULTY_COLOR: Record<string, string> = {
 
 export function PresetCard({ preset }: PresetCardProps) {
   const [hovered, setHovered] = useState(false);
+  const navigate = useNavigate();
   const diff = DIFFICULTY_LABEL[preset.id] ?? "初級";
   const diffColor = DIFFICULTY_COLOR[diff] ?? "#4ecdc4";
 
@@ -106,10 +107,28 @@ export function PresetCard({ preset }: PresetCardProps) {
         style={{
           display: "flex",
           alignItems: "center",
-          justifyContent: "flex-end",
+          justifyContent: "space-between",
+          gap: 8,
           marginTop: 4,
         }}
       >
+        <span
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate(`/editor?clone=${preset.id}`);
+          }}
+          role="button"
+          tabIndex={0}
+          style={{
+            font: "500 12px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+            cursor: "pointer",
+            textDecoration: "underline",
+          }}
+        >
+          コピーして編集
+        </span>
         <span
           style={{
             font: "500 13px/1 Roboto, sans-serif",

--- a/src/components/practice/PresetCard.tsx
+++ b/src/components/practice/PresetCard.tsx
@@ -26,12 +26,11 @@ export function PresetCard({ preset }: PresetCardProps) {
   const diffColor = DIFFICULTY_COLOR[diff] ?? "#4ecdc4";
 
   return (
-    <Link
-      to={`/practice/tab/${preset.id}`}
+    <div
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
-        textDecoration: "none",
+        position: "relative",
         background: hovered
           ? "var(--md-surface-container-highest)"
           : "var(--md-surface-container-high)",
@@ -49,6 +48,16 @@ export function PresetCard({ preset }: PresetCardProps) {
         height: "100%",
       }}
     >
+      <Link
+        to={`/practice/tab/${preset.id}`}
+        aria-label={`${preset.name} で練習を始める`}
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: 16,
+          textDecoration: "none",
+        }}
+      />
       <div
         style={{
           display: "flex",
@@ -112,15 +121,18 @@ export function PresetCard({ preset }: PresetCardProps) {
           marginTop: 4,
         }}
       >
-        <span
+        <button
+          type="button"
           onClick={(e) => {
-            e.preventDefault();
             e.stopPropagation();
             navigate(`/editor?clone=${preset.id}`);
           }}
-          role="button"
-          tabIndex={0}
           style={{
+            position: "relative",
+            zIndex: 1,
+            background: "transparent",
+            border: "none",
+            padding: 0,
             font: "500 12px/1 Roboto, sans-serif",
             color: "var(--md-on-surface-variant)",
             cursor: "pointer",
@@ -128,7 +140,7 @@ export function PresetCard({ preset }: PresetCardProps) {
           }}
         >
           コピーして編集
-        </span>
+        </button>
         <span
           style={{
             font: "500 13px/1 Roboto, sans-serif",
@@ -141,6 +153,6 @@ export function PresetCard({ preset }: PresetCardProps) {
           練習を始める →
         </span>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/src/hooks/useCustomTabs.ts
+++ b/src/hooks/useCustomTabs.ts
@@ -1,0 +1,70 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type { TabPreset } from "../types/practice";
+import {
+  CUSTOM_TABS_STORAGE_KEY,
+  loadCustomTabs,
+  saveCustomTabs,
+} from "../lib/customTabs";
+
+// Simple event-based store so multiple hook consumers stay in sync.
+type Listener = () => void;
+const listeners = new Set<Listener>();
+let cache: TabPreset[] | null = null;
+
+function getSnapshot(): TabPreset[] {
+  if (cache === null) cache = loadCustomTabs();
+  return cache;
+}
+
+function getServerSnapshot(): TabPreset[] {
+  return [];
+}
+
+function notify() {
+  cache = loadCustomTabs();
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === CUSTOM_TABS_STORAGE_KEY) notify();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function mutate(next: TabPreset[]) {
+  saveCustomTabs(next);
+  notify();
+}
+
+export function useCustomTabs() {
+  const tabs = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const upsert = useCallback((tab: TabPreset) => {
+    const current = getSnapshot();
+    const idx = current.findIndex((t) => t.id === tab.id);
+    const next = idx >= 0
+      ? current.map((t, i) => (i === idx ? tab : t))
+      : [...current, tab];
+    mutate(next);
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    mutate(getSnapshot().filter((t) => t.id !== id));
+  }, []);
+
+  const getById = useCallback((id: string): TabPreset | undefined => {
+    return getSnapshot().find((t) => t.id === id);
+  }, []);
+
+  return { tabs, upsert, remove, getById };
+}
+
+export function findCustomTab(id: string): TabPreset | undefined {
+  return getSnapshot().find((t) => t.id === id);
+}

--- a/src/lib/customTabs.test.ts
+++ b/src/lib/customTabs.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  CUSTOM_TABS_STORAGE_KEY,
+  cloneAsCustom,
+  createEmptyPreset,
+  loadCustomTabs,
+  resizeNotes,
+  saveCustomTabs,
+  toggleNote,
+} from "./customTabs";
+import type { TabPreset } from "../types/practice";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("customTabs persistence", () => {
+  it("returns [] when nothing stored", () => {
+    expect(loadCustomTabs()).toEqual([]);
+  });
+
+  it("roundtrips via save/load", () => {
+    const preset = createEmptyPreset({ name: "Foo" });
+    saveCustomTabs([preset]);
+    expect(loadCustomTabs()).toEqual([preset]);
+  });
+
+  it("ignores corrupt JSON", () => {
+    localStorage.setItem(CUSTOM_TABS_STORAGE_KEY, "{ not json");
+    expect(loadCustomTabs()).toEqual([]);
+  });
+
+  it("filters invalid entries", () => {
+    localStorage.setItem(
+      CUSTOM_TABS_STORAGE_KEY,
+      JSON.stringify([{ broken: true }, createEmptyPreset({ name: "ok" })]),
+    );
+    const loaded = loadCustomTabs();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].name).toBe("ok");
+  });
+});
+
+describe("cloneAsCustom", () => {
+  it("generates new id and appends suffix", () => {
+    const src: TabPreset = createEmptyPreset({ id: "orig", name: "Foo" });
+    const copy = cloneAsCustom(src);
+    expect(copy.id).not.toBe("orig");
+    expect(copy.name).toBe("Foo (コピー)");
+    expect(copy.notes).not.toBe(src.notes);
+  });
+});
+
+describe("resizeNotes", () => {
+  it("drops notes beyond total beats", () => {
+    const notes = [
+      { string: 1, fret: 0, beat: 0 },
+      { string: 1, fret: 0, beat: 7 },
+      { string: 1, fret: 0, beat: 8 },
+    ];
+    const result = resizeNotes(notes, { beatsPerMeasure: 4, beatUnit: 4 }, 2);
+    expect(result).toHaveLength(2);
+    expect(result.map((n) => n.beat)).toEqual([0, 7]);
+  });
+});
+
+describe("toggleNote", () => {
+  it("adds a new note", () => {
+    const result = toggleNote([], 1, 0, 5);
+    expect(result).toEqual([{ string: 1, fret: 5, beat: 0 }]);
+  });
+
+  it("removes when same fret clicked twice", () => {
+    const start = [{ string: 1, fret: 5, beat: 0 }];
+    expect(toggleNote(start, 1, 0, 5)).toEqual([]);
+  });
+
+  it("replaces fret when different", () => {
+    const start = [{ string: 1, fret: 5, beat: 0 }];
+    const result = toggleNote(start, 1, 0, 7);
+    expect(result).toEqual([{ string: 1, fret: 7, beat: 0 }]);
+  });
+});

--- a/src/lib/customTabs.ts
+++ b/src/lib/customTabs.ts
@@ -1,0 +1,96 @@
+import type { TabPreset, TabNote, TimeSignature } from "../types/practice";
+
+export const CUSTOM_TABS_STORAGE_KEY = "bass-practice.customTabs.v1";
+
+export function loadCustomTabs(): TabPreset[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(CUSTOM_TABS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidPreset);
+  } catch {
+    return [];
+  }
+}
+
+export function saveCustomTabs(tabs: TabPreset[]): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(CUSTOM_TABS_STORAGE_KEY, JSON.stringify(tabs));
+}
+
+function isValidPreset(value: unknown): value is TabPreset {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "string" &&
+    typeof v.name === "string" &&
+    typeof v.description === "string" &&
+    typeof v.bpm === "number" &&
+    typeof v.measures === "number" &&
+    v.timeSignature != null &&
+    typeof v.timeSignature === "object" &&
+    Array.isArray(v.notes)
+  );
+}
+
+export function generateId(): string {
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `custom-${Date.now().toString(36)}-${rand}`;
+}
+
+export function createEmptyPreset(overrides: Partial<TabPreset> = {}): TabPreset {
+  return {
+    id: generateId(),
+    name: "新しいタブ譜",
+    description: "",
+    bpm: 90,
+    timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+    measures: 2,
+    notes: [],
+    ...overrides,
+  };
+}
+
+export function cloneAsCustom(preset: TabPreset, nameSuffix = " (コピー)"): TabPreset {
+  return {
+    ...preset,
+    id: generateId(),
+    name: preset.name + nameSuffix,
+    notes: preset.notes.map((n) => ({ ...n })),
+    timeSignature: { ...preset.timeSignature },
+  };
+}
+
+/**
+ * Resize preset notes to fit new time signature / measures.
+ * Drops notes whose beat falls outside the new total beat count.
+ */
+export function resizeNotes(
+  notes: TabNote[],
+  timeSignature: TimeSignature,
+  measures: number,
+): TabNote[] {
+  const total = timeSignature.beatsPerMeasure * measures;
+  return notes.filter((n) => n.beat < total);
+}
+
+export function toggleNote(
+  notes: TabNote[],
+  stringNum: number,
+  beat: number,
+  fret: number,
+): TabNote[] {
+  const existingIdx = notes.findIndex(
+    (n) => n.string === stringNum && n.beat === beat,
+  );
+  if (existingIdx >= 0) {
+    // Same fret => remove. Different fret => replace.
+    if (notes[existingIdx].fret === fret) {
+      return notes.filter((_, i) => i !== existingIdx);
+    }
+    return notes.map((n, i) => (i === existingIdx ? { ...n, fret } : n));
+  }
+  return [...notes, { string: stringNum, fret, beat }];
+}

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useState, type CSSProperties } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { TabPreset, TimeSignature } from "../types/practice";
 import { tabPresets } from "../data/tabPresets";
@@ -7,7 +7,7 @@ import {
   createEmptyPreset,
   resizeNotes,
 } from "../lib/customTabs";
-import { useCustomTabs } from "../hooks/useCustomTabs";
+import { findCustomTab, useCustomTabs } from "../hooks/useCustomTabs";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { TabGrid } from "../components/editor/TabGrid";
 import { AsciiTabDisplay } from "../components/practice/AsciiTabDisplay";
@@ -21,32 +21,24 @@ export function EditorPage() {
   const { tabs, upsert, remove } = useCustomTabs();
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
-  // Initial preset is derived ONCE from URL params; we don't want it to reset
-  // while the user is editing. `useMemo` with a key-dependency set to `id`
-  // would re-fetch when the route changes (e.g. after first save).
-  const initial = useMemo<TabPreset>(() => {
-    if (id) {
-      const existing = tabs.find((t) => t.id === id);
-      if (existing) return existing;
-    }
-    if (clonePresetId) {
-      const src =
-        tabPresets.find((p) => p.id === clonePresetId) ??
-        tabs.find((t) => t.id === clonePresetId);
-      if (src) return cloneAsCustom(src);
-    }
-    return createEmptyPreset();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
-
-  const [draft, setDraft] = useState<TabPreset>(initial);
+  // Initial preset is derived from URL params. We read the store synchronously
+  // via `findCustomTab` (not the `tabs` snapshot) to avoid depending on the
+  // order in which components subscribe. The draft is then owned by local
+  // state and only reset when the route `id` changes.
+  const [draft, setDraft] = useState<TabPreset>(() =>
+    buildInitialPreset(id, clonePresetId),
+  );
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
 
-  // When route id changes (new/edit switch), reset draft.
-  useEffect(() => {
-    setDraft(initial);
+  // Reset draft when the route id changes (new/edit switch). Using the
+  // "changing key during render" pattern rather than useEffect avoids a
+  // wasted render and the cascading-setState lint warning.
+  const [prevId, setPrevId] = useState(id);
+  if (prevId !== id) {
+    setPrevId(id);
+    setDraft(buildInitialPreset(id, clonePresetId));
     setSaveMsg(null);
-  }, [initial]);
+  }
 
   const updateField = <K extends keyof TabPreset>(key: K, value: TabPreset[K]) => {
     setDraft((d) => ({ ...d, [key]: value }));
@@ -278,6 +270,23 @@ function LabeledNumber({ label, value, min, max, onChange }: LabeledNumberProps)
       />
     </label>
   );
+}
+
+function buildInitialPreset(
+  id: string | undefined,
+  clonePresetId: string | null,
+): TabPreset {
+  if (id) {
+    const existing = findCustomTab(id);
+    if (existing) return existing;
+  }
+  if (clonePresetId) {
+    const src =
+      tabPresets.find((p) => p.id === clonePresetId) ??
+      findCustomTab(clonePresetId);
+    if (src) return cloneAsCustom(src);
+  }
+  return createEmptyPreset();
 }
 
 const inputStyle: CSSProperties = {

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { TabPreset, TimeSignature } from "../types/practice";
 import { tabPresets } from "../data/tabPresets";
@@ -243,6 +243,26 @@ interface LabeledNumberProps {
 }
 
 function LabeledNumber({ label, value, min, max, onChange }: LabeledNumberProps) {
+  // Keep a local string buffer so the user can transiently clear the field
+  // or type partial values without getting clamped on every keystroke.
+  const [text, setText] = useState(String(value));
+
+  // Sync buffer when the committed value changes from outside (e.g. resize).
+  useEffect(() => {
+    setText(String(value));
+  }, [value]);
+
+  const commit = (raw: string) => {
+    const n = Number(raw);
+    if (raw.trim() === "" || !Number.isFinite(n)) {
+      setText(String(value));
+      return;
+    }
+    const clamped = Math.max(min, Math.min(max, Math.trunc(n)));
+    setText(String(clamped));
+    if (clamped !== value) onChange(clamped);
+  };
+
   return (
     <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
       <span
@@ -259,11 +279,13 @@ function LabeledNumber({ label, value, min, max, onChange }: LabeledNumberProps)
         type="number"
         min={min}
         max={max}
-        value={value}
-        onChange={(e) => {
-          const n = Number(e.target.value);
-          if (Number.isFinite(n)) {
-            onChange(Math.max(min, Math.min(max, n)));
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={(e) => commit(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            commit((e.target as HTMLInputElement).value);
+            (e.target as HTMLInputElement).blur();
           }
         }}
         style={inputStyle}

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import type { TabPreset, TimeSignature } from "../types/practice";
+import { tabPresets } from "../data/tabPresets";
+import {
+  cloneAsCustom,
+  createEmptyPreset,
+  resizeNotes,
+} from "../lib/customTabs";
+import { useCustomTabs } from "../hooks/useCustomTabs";
+import { useMediaQuery } from "../hooks/useMediaQuery";
+import { TabGrid } from "../components/editor/TabGrid";
+import { AsciiTabDisplay } from "../components/practice/AsciiTabDisplay";
+import { FilledButton, OutlinedButton, SectionLabel } from "../components/md3";
+
+export function EditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const clonePresetId = searchParams.get("clone");
+  const navigate = useNavigate();
+  const { tabs, upsert, remove } = useCustomTabs();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  // Initial preset is derived ONCE from URL params; we don't want it to reset
+  // while the user is editing. `useMemo` with a key-dependency set to `id`
+  // would re-fetch when the route changes (e.g. after first save).
+  const initial = useMemo<TabPreset>(() => {
+    if (id) {
+      const existing = tabs.find((t) => t.id === id);
+      if (existing) return existing;
+    }
+    if (clonePresetId) {
+      const src =
+        tabPresets.find((p) => p.id === clonePresetId) ??
+        tabs.find((t) => t.id === clonePresetId);
+      if (src) return cloneAsCustom(src);
+    }
+    return createEmptyPreset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const [draft, setDraft] = useState<TabPreset>(initial);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+
+  // When route id changes (new/edit switch), reset draft.
+  useEffect(() => {
+    setDraft(initial);
+    setSaveMsg(null);
+  }, [initial]);
+
+  const updateField = <K extends keyof TabPreset>(key: K, value: TabPreset[K]) => {
+    setDraft((d) => ({ ...d, [key]: value }));
+  };
+
+  const updateTimeSignature = (patch: Partial<TimeSignature>) => {
+    setDraft((d) => {
+      const ts = { ...d.timeSignature, ...patch };
+      return {
+        ...d,
+        timeSignature: ts,
+        notes: resizeNotes(d.notes, ts, d.measures),
+      };
+    });
+  };
+
+  const updateMeasures = (measures: number) => {
+    setDraft((d) => ({
+      ...d,
+      measures,
+      notes: resizeNotes(d.notes, d.timeSignature, measures),
+    }));
+  };
+
+  const handleSave = () => {
+    if (!draft.name.trim()) {
+      setSaveMsg("タイトルを入力してください");
+      return;
+    }
+    upsert(draft);
+    setSaveMsg("保存しました");
+    // Navigate to edit URL so subsequent saves update in-place.
+    if (!id) navigate(`/editor/${draft.id}`, { replace: true });
+  };
+
+  const handleDelete = () => {
+    if (!id) return;
+    if (!confirm("このタブ譜を削除しますか？")) return;
+    remove(id);
+    navigate("/");
+  };
+
+  const handlePractice = () => {
+    upsert(draft);
+    navigate(`/practice/tab/${draft.id}`);
+  };
+
+  const isExisting = !!id && tabs.some((t) => t.id === id);
+
+  return (
+    <div
+      style={{
+        padding: isDesktop ? "32px 32px" : "24px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Link
+          to="/"
+          style={{
+            color: "var(--md-primary)",
+            textDecoration: "none",
+            font: "500 13px/1 Roboto, sans-serif",
+          }}
+        >
+          ← ホーム
+        </Link>
+      </div>
+
+      <SectionLabel>メタ情報</SectionLabel>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: isDesktop ? "2fr 1fr 1fr 1fr 1fr" : "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <LabeledInput
+          label="タイトル"
+          value={draft.name}
+          onChange={(v) => updateField("name", v)}
+        />
+        <LabeledNumber
+          label="BPM"
+          value={draft.bpm}
+          min={30}
+          max={300}
+          onChange={(v) => updateField("bpm", v)}
+        />
+        <LabeledNumber
+          label="拍/小節"
+          value={draft.timeSignature.beatsPerMeasure}
+          min={1}
+          max={12}
+          onChange={(v) => updateTimeSignature({ beatsPerMeasure: v })}
+        />
+        <LabeledNumber
+          label="音符値"
+          value={draft.timeSignature.beatUnit}
+          min={1}
+          max={16}
+          onChange={(v) => updateTimeSignature({ beatUnit: v })}
+        />
+        <LabeledNumber
+          label="小節数"
+          value={draft.measures}
+          min={1}
+          max={32}
+          onChange={updateMeasures}
+        />
+      </div>
+
+      <LabeledInput
+        label="説明"
+        value={draft.description}
+        onChange={(v) => updateField("description", v)}
+      />
+
+      <SectionLabel>プレビュー</SectionLabel>
+      <AsciiTabDisplay
+        preset={draft}
+        currentBeat={-1}
+        isPlaying={false}
+        beatWidth={isDesktop ? 56 : 44}
+      />
+
+      <SectionLabel>グリッド編集</SectionLabel>
+      <TabGrid
+        preset={draft}
+        onNotesChange={(notes) => updateField("notes", notes)}
+      />
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <FilledButton label="💾 保存" onClick={handleSave} />
+        <OutlinedButton
+          label="🎸 保存して練習"
+          onClick={handlePractice}
+          disabled={!draft.name.trim()}
+        />
+        {isExisting && (
+          <OutlinedButton
+            label="🗑️ 削除"
+            onClick={handleDelete}
+            style={{ color: "#ef5350", borderColor: "#ef535066" }}
+          />
+        )}
+        {saveMsg && (
+          <span
+            style={{
+              alignSelf: "center",
+              font: "400 13px/1 Roboto, sans-serif",
+              color: "var(--md-on-surface-variant)",
+            }}
+          >
+            {saveMsg}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface LabeledInputProps {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}
+
+function LabeledInput({ label, value, onChange }: LabeledInputProps) {
+  return (
+    <label
+      style={{ display: "flex", flexDirection: "column", gap: 4, flex: 1 }}
+    >
+      <span
+        style={{
+          font: "500 11px/1 Roboto, sans-serif",
+          letterSpacing: 1.2,
+          textTransform: "uppercase",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        {label}
+      </span>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={inputStyle}
+      />
+    </label>
+  );
+}
+
+interface LabeledNumberProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}
+
+function LabeledNumber({ label, value, min, max, onChange }: LabeledNumberProps) {
+  return (
+    <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <span
+        style={{
+          font: "500 11px/1 Roboto, sans-serif",
+          letterSpacing: 1.2,
+          textTransform: "uppercase",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        {label}
+      </span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (Number.isFinite(n)) {
+            onChange(Math.max(min, Math.min(max, n)));
+          }
+        }}
+        style={inputStyle}
+      />
+    </label>
+  );
+}
+
+const inputStyle: CSSProperties = {
+  background: "var(--md-surface-container)",
+  border: "1px solid var(--md-outline-variant)",
+  color: "var(--md-on-surface)",
+  borderRadius: 8,
+  padding: "10px 12px",
+  font: "400 14px/1.2 Roboto, sans-serif",
+  width: "100%",
+  boxSizing: "border-box",
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,14 @@
+import { Link } from "react-router-dom";
 import { PresetCard } from "../components/practice/PresetCard";
+import { CustomTabCard } from "../components/practice/CustomTabCard";
 import { AssistChip, SectionLabel } from "../components/md3";
 import { tabPresets } from "../data/tabPresets";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { useCustomTabs } from "../hooks/useCustomTabs";
 
 export function HomePage() {
   const isDesktop = useMediaQuery("(min-width: 768px)");
+  const { tabs: customTabs, remove } = useCustomTabs();
 
   return (
     <div
@@ -55,7 +59,7 @@ export function HomePage() {
 
       {/* Preset list */}
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <SectionLabel>タブ譜を選ぶ</SectionLabel>
+        <SectionLabel>プリセット</SectionLabel>
         <div
           style={{
             display: "grid",
@@ -67,6 +71,72 @@ export function HomePage() {
             <PresetCard key={preset.id} preset={preset} />
           ))}
         </div>
+      </div>
+
+      {/* Custom tabs */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 8,
+          }}
+        >
+          <SectionLabel>マイタブ譜</SectionLabel>
+          <Link
+            to="/editor"
+            style={{
+              textDecoration: "none",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              background: "var(--md-primary)",
+              color: "var(--md-on-primary)",
+              padding: "8px 16px",
+              borderRadius: 20,
+              font: "500 13px/1 Roboto, sans-serif",
+              marginBottom: 8,
+            }}
+          >
+            + タブ譜を作る
+          </Link>
+        </div>
+        {customTabs.length === 0 ? (
+          <div
+            style={{
+              padding: "20px 16px",
+              borderRadius: 16,
+              background: "var(--md-surface-container-low)",
+              border: "1px dashed var(--md-outline-variant)",
+              color: "var(--md-on-surface-variant)",
+              font: "400 13px/1.6 Roboto, sans-serif",
+              textAlign: "center",
+            }}
+          >
+            まだマイタブ譜がありません。「タブ譜を作る」から始めるか、プリセットをコピーして編集してみましょう。
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: isDesktop ? "1fr 1fr" : "1fr",
+              gap: 12,
+            }}
+          >
+            {customTabs.map((preset) => (
+              <CustomTabCard
+                key={preset.id}
+                preset={preset}
+                onDelete={() => {
+                  if (confirm(`「${preset.name}」を削除しますか？`)) {
+                    remove(preset.id);
+                  }
+                }}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { tabPresets } from "../data/tabPresets";
+import { useCustomTabs } from "../hooks/useCustomTabs";
 import { useAudioInput } from "../hooks/useAudioInput";
 import { useTabPractice } from "../hooks/useTabPractice";
 import { AsciiTabDisplay } from "../components/practice/AsciiTabDisplay";
@@ -13,7 +14,10 @@ import type { TabPreset } from "../types/practice";
 
 export function TabPracticePage() {
   const { presetId } = useParams<{ presetId: string }>();
-  const preset = tabPresets.find((p) => p.id === presetId);
+  const { tabs: customTabs } = useCustomTabs();
+  const preset =
+    tabPresets.find((p) => p.id === presetId) ??
+    customTabs.find((p) => p.id === presetId);
 
   if (!preset) {
     return (


### PR DESCRIPTION
Close #43

## 概要
ユーザーが自分でタブ譜を作成・編集・保存できるエディタを追加しました。

## 実装内容

### 新規ルート
- `/editor` — 新規作成
- `/editor/:id` — 編集
- `/editor?clone=:presetId` — プリセットをコピーして編集

### 機能
- [x] 4弦ベースのタブ譜をGUIで入力（弦×拍のマトリックスをクリックで配置／削除）
- [x] BPM、拍子（time signature）、小節数の設定
- [x] ノートの追加・削除・置き換え（同じセル再タップで削除、別フレット選択で差し替え）
- [x] 作成したタブ譜を localStorage に JSON で保存（`bass-practice.customTabs.v1`）
- [x] 保存したタブ譜の一覧表示・編集・削除（ホーム画面「マイタブ譜」セクション）
- [x] 保存したタブ譜でそのまま練習モード（`/practice/tab/:id`）に入れる
- [x] プリセットをコピーして編集（各プリセットカードに「コピーして編集」リンク）

## 主なファイル
- `src/lib/customTabs.ts` — localStorage CRUD / ID生成 / リサイズロジック
- `src/hooks/useCustomTabs.ts` — `useSyncExternalStore` で複数コンシューマとタブ間同期
- `src/pages/EditorPage.tsx` — エディタページ本体
- `src/components/editor/TabGrid.tsx` — 編集グリッドUI
- `src/components/practice/CustomTabCard.tsx` — 一覧カード
- `src/lib/customTabs.test.ts` — 永続化・リサイズ・トグルのユニットテスト

## 動作確認
- ✅ `npm run build`
- ✅ `npm run lint`
- ✅ `npm test -- --run` (186 tests passed, +9 new)
- ✅ ブラウザで新規作成→保存→ホーム一覧→編集→練習の一連フロー確認

## メモ
- 拍子や小節数を縮めると範囲外のノートは自動で落ちます（`resizeNotes`）
- Layoutは `/editor` ではナビを隠し、戻るボタンを表示
- 既存の `TabPreset` 型をそのまま流用し、練習モードは変更最小限で対応