### PR TITLE
feat: スケール練習モード (#44)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { HomePage } from "./pages/HomePage";
 import { TunerPage } from "./pages/TunerPage";
 import { TabPracticePage } from "./pages/TabPracticePage";
 import { EditorPage } from "./pages/EditorPage";
+import { ScalePracticePage } from "./pages/ScalePracticePage";
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route path="/practice/tab/:presetId" element={<TabPracticePage />} />
         <Route path="/editor" element={<EditorPage />} />
         <Route path="/editor/:id" element={<EditorPage />} />
+        <Route path="/practice/scale" element={<ScalePracticePage />} />
       </Route>
     </Routes>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,7 @@ export function Layout() {
   const { tabs: customTabs } = useCustomTabs();
   const isPractice = location.pathname.startsWith("/practice/tab/");
   const isEditor = location.pathname.startsWith("/editor");
+  const isScalePractice = location.pathname === "/practice/scale";
   const practicePreset = isPractice
     ? (tabPresets.find((p) => p.id === params.presetId) ??
       customTabs.find((p) => p.id === params.presetId))
@@ -23,12 +24,14 @@ export function Layout() {
       ? (params.id
           ? (customTabs.find((t) => t.id === params.id)?.name ?? "タブ譜を編集")
           : "タブ譜を作る")
-      : location.pathname === "/tuner"
-        ? "チューナー"
-        : "Bass Practice";
+      : isScalePractice
+        ? "スケール練習"
+        : location.pathname === "/tuner"
+          ? "チューナー"
+          : "Bass Practice";
 
   const currentTab = location.pathname === "/tuner" ? "tuner" : "home";
-  const hideNav = isPractice || isEditor;
+  const hideNav = isPractice || isEditor || isScalePractice;
 
   return (
     <div

--- a/src/components/scale/Fretboard.tsx
+++ b/src/components/scale/Fretboard.tsx
@@ -1,0 +1,240 @@
+import type { FretPosition } from "../../types/music";
+
+interface FretboardProps {
+  positions: FretPosition[];
+  rootPitchClass: string;
+  startFret: number;
+  endFret: number;
+  highlightPosition?: FretPosition | null;
+  detectedPitchClass?: string | null;
+}
+
+const STRING_LABELS = ["G", "D", "A", "E"]; // string 1..4
+const INLAY_FRETS = new Set([3, 5, 7, 9, 15, 17, 19, 21]);
+const DOUBLE_INLAY_FRETS = new Set([12, 24]);
+
+export function Fretboard({
+  positions,
+  rootPitchClass,
+  startFret,
+  endFret,
+  highlightPosition,
+  detectedPitchClass,
+}: FretboardProps) {
+  const fretCount = endFret - startFret + 1;
+  // +1 for the nut/open column
+  const cols = fretCount;
+  const rows = 4;
+
+  return (
+    <div
+      style={{
+        background: "var(--md-surface-container)",
+        borderRadius: 16,
+        padding: 12,
+        overflowX: "auto",
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: `28px repeat(${cols}, minmax(44px, 1fr))`,
+          gridTemplateRows: `auto repeat(${rows}, 40px) auto`,
+          gap: 0,
+          minWidth: cols * 44 + 28,
+        }}
+      >
+        {/* Top fret numbers */}
+        <div />
+        {Array.from({ length: fretCount }, (_, i) => {
+          const fret = startFret + i;
+          return (
+            <div
+              key={`top-${fret}`}
+              style={{
+                textAlign: "center",
+                font: "500 11px/1 Roboto, sans-serif",
+                color: "var(--md-on-surface-variant)",
+                paddingBottom: 4,
+              }}
+            >
+              {fret}
+            </div>
+          );
+        })}
+
+        {Array.from({ length: rows }, (_, r) => {
+          const stringNum = r + 1; // 1..4
+          return (
+            <FretRow
+              key={`row-${stringNum}`}
+              stringNum={stringNum}
+              stringLabel={STRING_LABELS[r]}
+              startFret={startFret}
+              endFret={endFret}
+              positions={positions}
+              rootPitchClass={rootPitchClass}
+              highlightPosition={highlightPosition ?? null}
+              detectedPitchClass={detectedPitchClass ?? null}
+            />
+          );
+        })}
+
+        {/* Inlays row */}
+        <div />
+        {Array.from({ length: fretCount }, (_, i) => {
+          const fret = startFret + i;
+          return (
+            <div
+              key={`inlay-${fret}`}
+              style={{
+                height: 18,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 4,
+              }}
+            >
+              {DOUBLE_INLAY_FRETS.has(fret) ? (
+                <>
+                  <Dot />
+                  <Dot />
+                </>
+              ) : INLAY_FRETS.has(fret) ? (
+                <Dot />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Dot() {
+  return (
+    <span
+      style={{
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        background: "var(--md-outline)",
+        display: "inline-block",
+      }}
+    />
+  );
+}
+
+interface FretRowProps {
+  stringNum: number;
+  stringLabel: string;
+  startFret: number;
+  endFret: number;
+  positions: FretPosition[];
+  rootPitchClass: string;
+  highlightPosition: FretPosition | null;
+  detectedPitchClass: string | null;
+}
+
+function FretRow({
+  stringNum,
+  stringLabel,
+  startFret,
+  endFret,
+  positions,
+  rootPitchClass,
+  highlightPosition,
+  detectedPitchClass,
+}: FretRowProps) {
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          font: "500 12px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        {stringLabel}
+      </div>
+      {Array.from({ length: endFret - startFret + 1 }, (_, i) => {
+        const fret = startFret + i;
+        const pos = positions.find(
+          (p) => p.string === stringNum && p.fret === fret,
+        );
+        const isRoot = pos && pos.pitchClass === rootPitchClass;
+        const isHighlight =
+          highlightPosition &&
+          highlightPosition.string === stringNum &&
+          highlightPosition.fret === fret;
+        const isDetected =
+          pos && detectedPitchClass && pos.pitchClass === detectedPitchClass;
+
+        return (
+          <div
+            key={`cell-${stringNum}-${fret}`}
+            style={{
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRight:
+                fret === 0
+                  ? "3px solid var(--md-on-surface-variant)"
+                  : "1px solid var(--md-outline-variant)",
+              borderLeft: i === 0 ? "1px solid var(--md-outline-variant)" : "",
+            }}
+          >
+            {/* String line */}
+            <div
+              style={{
+                position: "absolute",
+                left: 0,
+                right: 0,
+                top: "50%",
+                height: 1 + Math.max(0, 4 - stringNum) * 0.3,
+                background: "var(--md-outline)",
+                opacity: 0.5,
+              }}
+            />
+            {pos && (
+              <div
+                style={{
+                  position: "relative",
+                  zIndex: 1,
+                  width: isHighlight ? 32 : 26,
+                  height: isHighlight ? 32 : 26,
+                  borderRadius: "50%",
+                  background: isHighlight
+                    ? "var(--md-tertiary)"
+                    : isRoot
+                      ? "var(--md-primary)"
+                      : "var(--md-secondary-container)",
+                  color: isHighlight
+                    ? "var(--md-on-tertiary)"
+                    : isRoot
+                      ? "var(--md-on-primary)"
+                      : "var(--md-on-secondary-container)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  font: `${isRoot || isHighlight ? 600 : 500} 11px/1 Roboto, sans-serif`,
+                  boxShadow: isHighlight
+                    ? "0 0 0 3px var(--md-tertiary-container)"
+                    : isDetected
+                      ? "0 0 0 3px var(--md-primary)"
+                      : "0 1px 2px rgba(0,0,0,0.2)",
+                  transition: "all 120ms ease",
+                }}
+              >
+                {pos.pitchClass}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/lib/music/scales.test.ts
+++ b/src/lib/music/scales.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  getScalePitchClasses,
+  isPitchClassInScale,
+  getScaleFretPositions,
+  buildAscDescSequence,
+} from "./scales";
+
+describe("scales", () => {
+  it("C major -> 7 notes starting at C", () => {
+    const s = getScalePitchClasses("C", "major");
+    expect(s.pitchClasses).toEqual(["C", "D", "E", "F", "G", "A", "B"]);
+  });
+
+  it("A minor pentatonic -> 5 notes", () => {
+    const s = getScalePitchClasses("A", "minor pentatonic");
+    expect(s.pitchClasses.length).toBe(5);
+    expect(s.pitchClasses[0]).toBe("A");
+  });
+
+  it("isPitchClassInScale handles enharmonic equivalents", () => {
+    const s = getScalePitchClasses("F", "major"); // includes Bb
+    expect(isPitchClassInScale("A#", s.pitchClasses)).toBe(true);
+    expect(isPitchClassInScale("B", s.pitchClasses)).toBe(false);
+  });
+
+  it("getScaleFretPositions returns positions across 4 strings", () => {
+    const s = getScalePitchClasses("C", "major");
+    const pos = getScaleFretPositions(s.pitchClasses, 0, 5);
+    expect(pos.length).toBeGreaterThan(0);
+    for (const p of pos) {
+      expect(p.string).toBeGreaterThanOrEqual(1);
+      expect(p.string).toBeLessThanOrEqual(4);
+      expect(p.fret).toBeGreaterThanOrEqual(0);
+      expect(p.fret).toBeLessThanOrEqual(5);
+    }
+    // E at open 4th string should be a member of C major
+    expect(
+      pos.some((p) => p.string === 4 && p.fret === 0 && p.pitchClass === "E"),
+    ).toBe(true);
+    // F at fret 1 of 4th string
+    expect(
+      pos.some((p) => p.string === 4 && p.fret === 1 && p.pitchClass === "F"),
+    ).toBe(true);
+  });
+
+  it("buildAscDescSequence ascends then descends an octave", () => {
+    const s = getScalePitchClasses("C", "major");
+    const seq = buildAscDescSequence(s.pitchClasses, 2);
+    // 7 notes + octave root + descending (without top dup) = 15
+    expect(seq.length).toBe(15);
+    expect(seq[0]).toBe("C2");
+    expect(seq[7]).toBe("C3");
+    expect(seq[seq.length - 1]).toBe("C2");
+  });
+});

--- a/src/lib/music/scales.test.ts
+++ b/src/lib/music/scales.test.ts
@@ -4,6 +4,7 @@ import {
   isPitchClassInScale,
   getScaleFretPositions,
   buildAscDescSequence,
+  normalizePitchClass,
 } from "./scales";
 
 describe("scales", () => {
@@ -42,6 +43,13 @@ describe("scales", () => {
     expect(
       pos.some((p) => p.string === 4 && p.fret === 1 && p.pitchClass === "F"),
     ).toBe(true);
+  });
+
+  it("normalizePitchClass converts flats to sharps", () => {
+    expect(normalizePitchClass("Bb")).toBe("A#");
+    expect(normalizePitchClass("Eb")).toBe("D#");
+    expect(normalizePitchClass("A#")).toBe("A#");
+    expect(normalizePitchClass("C")).toBe("C");
   });
 
   it("buildAscDescSequence ascends then descends an octave", () => {

--- a/src/lib/music/scales.ts
+++ b/src/lib/music/scales.ts
@@ -55,7 +55,7 @@ export function getScalePitchClasses(
   return { key, type, pitchClasses: pcs };
 }
 
-function normalizePitchClass(pc: string): string {
+export function normalizePitchClass(pc: string): string {
   // Canonicalize to sharp-notation pitch class via MIDI round-trip.
   if (!pc) return pc;
   const midi = Note.midi(`${pc}4`);

--- a/src/lib/music/scales.ts
+++ b/src/lib/music/scales.ts
@@ -1,0 +1,141 @@
+import { Scale, Note } from "tonal";
+import type { FretPosition } from "../../types/music";
+
+// Chromatic keys (sharp convention, matching tonal defaults used in this project)
+export const KEYS = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+] as const;
+
+export type Key = (typeof KEYS)[number];
+
+// Curated scale list (matches issue requirements)
+export const SCALE_TYPES = [
+  { id: "major", label: "Major" },
+  { id: "minor", label: "Natural Minor" },
+  { id: "major pentatonic", label: "Major Pentatonic" },
+  { id: "minor pentatonic", label: "Minor Pentatonic" },
+  { id: "minor blues", label: "Blues" },
+  { id: "dorian", label: "Dorian" },
+  { id: "mixolydian", label: "Mixolydian" },
+] as const;
+
+export type ScaleTypeId = (typeof SCALE_TYPES)[number]["id"];
+
+// Standard 4-string bass tuning (string 1 = G highest, string 4 = E lowest)
+// Open-string notes with octave suffix
+export const BASS_TUNING_OPEN_NOTES = ["G2", "D2", "A1", "E1"] as const;
+
+export interface ScalePitchClasses {
+  key: Key;
+  type: ScaleTypeId;
+  pitchClasses: string[]; // e.g. ["C", "D", "E", ...]
+}
+
+/**
+ * Resolve the pitch classes of a scale (root first). Returns empty if invalid.
+ * Uses tonal's Scale.get("<root> <type>").
+ */
+export function getScalePitchClasses(
+  key: Key,
+  type: ScaleTypeId,
+): ScalePitchClasses {
+  const s = Scale.get(`${key} ${type}`);
+  const pcs = s.notes.map((n) => Note.pitchClass(n)).filter(Boolean);
+  return { key, type, pitchClasses: pcs };
+}
+
+function normalizePitchClass(pc: string): string {
+  // Canonicalize to sharp-notation pitch class via MIDI round-trip.
+  if (!pc) return pc;
+  const midi = Note.midi(`${pc}4`);
+  if (midi == null) return pc;
+  return Note.pitchClass(Note.fromMidiSharps(midi));
+}
+
+/**
+ * Returns true if the given pitch class is a member of the scale.
+ * Both inputs are normalized to sharp enharmonics.
+ */
+export function isPitchClassInScale(
+  pitchClass: string,
+  scalePitchClasses: string[],
+): boolean {
+  if (!pitchClass) return false;
+  const target = normalizePitchClass(pitchClass);
+  return scalePitchClasses.some((pc) => normalizePitchClass(pc) === target);
+}
+
+/**
+ * Compute all fret positions on a 4-string bass where a scale note occurs,
+ * within the given fret range (inclusive).
+ */
+export function getScaleFretPositions(
+  scalePitchClasses: string[],
+  startFret: number,
+  endFret: number,
+): FretPosition[] {
+  const positions: FretPosition[] = [];
+  const normalizedScale = scalePitchClasses.map(normalizePitchClass);
+
+  for (let s = 0; s < BASS_TUNING_OPEN_NOTES.length; s++) {
+    const openMidi = Note.midi(BASS_TUNING_OPEN_NOTES[s]);
+    if (openMidi == null) continue;
+    for (let fret = startFret; fret <= endFret; fret++) {
+      const midi = openMidi + fret;
+      const note = Note.fromMidiSharps(midi);
+      const pc = Note.pitchClass(note);
+      if (normalizedScale.includes(normalizePitchClass(pc))) {
+        const freq = Note.freq(note);
+        if (freq == null) continue;
+        positions.push({
+          string: s + 1,
+          fret,
+          note,
+          pitchClass: pc,
+          frequency: freq,
+        });
+      }
+    }
+  }
+  return positions;
+}
+
+/**
+ * Build an ascending-then-descending target sequence across one octave,
+ * starting from the lowest scale note playable from the given start fret
+ * on the 4th string.
+ */
+export function buildAscDescSequence(
+  scalePitchClasses: string[],
+  startOctave = 1,
+): string[] {
+  if (scalePitchClasses.length === 0) return [];
+  const root = scalePitchClasses[0];
+  // Build one octave: roots first-note -> up through scale -> octave root
+  const asc: string[] = scalePitchClasses.map((pc) => {
+    // Assign each pc to an octave so they ascend monotonically
+    const base = `${pc}${startOctave}`;
+    const midi = Note.midi(base);
+    const rootMidi = Note.midi(`${root}${startOctave}`) ?? 0;
+    if (midi == null) return base;
+    const adjusted = midi < rootMidi ? midi + 12 : midi;
+    return Note.fromMidiSharps(adjusted);
+  });
+  const octaveRootMidi = (Note.midi(`${root}${startOctave}`) ?? 0) + 12;
+  const octaveRoot = Note.fromMidiSharps(octaveRootMidi);
+  asc.push(octaveRoot);
+
+  const desc = [...asc].slice(0, -1).reverse();
+  return [...asc, ...desc];
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -57,6 +57,39 @@ export function HomePage() {
         </div>
       </div>
 
+      {/* Scale practice */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <SectionLabel>スケール練習</SectionLabel>
+        <Link
+          to="/practice/scale"
+          style={{
+            textDecoration: "none",
+            background: "var(--md-secondary-container)",
+            color: "var(--md-on-secondary-container)",
+            borderRadius: 16,
+            padding: "16px 18px",
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <span style={{ fontSize: 28 }}>🎼</span>
+          <span style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span style={{ font: "500 15px/1.3 Roboto, sans-serif" }}>
+              キー × スケールを選んで練習
+            </span>
+            <span
+              style={{
+                font: "400 12px/1.4 Roboto, sans-serif",
+                opacity: 0.8,
+              }}
+            >
+              指板上に構成音表示 + ガイド付き上行・下行
+            </span>
+          </span>
+        </Link>
+      </div>
+
       {/* Preset list */}
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <SectionLabel>プリセット</SectionLabel>

--- a/src/pages/ScalePracticePage.tsx
+++ b/src/pages/ScalePracticePage.tsx
@@ -1,0 +1,312 @@
+import { useMemo, useState, useRef, useEffect } from "react";
+import { Note } from "tonal";
+import { AudioSetup } from "../components/audio/AudioSetup";
+import { Fretboard } from "../components/scale/Fretboard";
+import { Card, FilledButton, OutlinedButton, SectionLabel } from "../components/md3";
+import { useAudioInput } from "../hooks/useAudioInput";
+import { usePitchDetection } from "../hooks/usePitchDetection";
+import { useMediaQuery } from "../hooks/useMediaQuery";
+import {
+  KEYS,
+  SCALE_TYPES,
+  getScalePitchClasses,
+  getScaleFretPositions,
+  isPitchClassInScale,
+  buildAscDescSequence,
+  type Key,
+  type ScaleTypeId,
+} from "../lib/music/scales";
+import type { FretPosition } from "../types/music";
+
+type PositionPreset = "low" | "high";
+
+const POSITION_RANGES: Record<PositionPreset, { start: number; end: number; label: string }> = {
+  low: { start: 0, end: 7, label: "ローポジション (0-7)" },
+  high: { start: 5, end: 12, label: "ハイポジション (5-12)" },
+};
+
+export function ScalePracticePage() {
+  const audio = useAudioInput();
+  const { pitch } = usePitchDetection(audio.engine, audio.isListening);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const [keyRoot, setKeyRoot] = useState<Key>("C");
+  const [scaleType, setScaleType] = useState<ScaleTypeId>("major");
+  const [position, setPosition] = useState<PositionPreset>("low");
+  const [isGuided, setIsGuided] = useState(false);
+  const [seqIndex, setSeqIndex] = useState(0);
+  const [hitCount, setHitCount] = useState(0);
+
+  const scale = useMemo(
+    () => getScalePitchClasses(keyRoot, scaleType),
+    [keyRoot, scaleType],
+  );
+
+  const { start, end } = POSITION_RANGES[position];
+
+  const positions = useMemo(
+    () => getScaleFretPositions(scale.pitchClasses, start, end),
+    [scale.pitchClasses, start, end],
+  );
+
+  const sequence = useMemo(
+    () => buildAscDescSequence(scale.pitchClasses, start >= 5 ? 2 : 1),
+    [scale.pitchClasses, start],
+  );
+
+  // Reset guided progress when settings change.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSeqIndex(0);
+    setHitCount(0);
+  }, [keyRoot, scaleType, position, isGuided]);
+
+  const currentTarget = isGuided ? sequence[seqIndex] : undefined;
+  const currentTargetPc = currentTarget ? Note.pitchClass(currentTarget) : undefined;
+  const targetFretPos = useMemo<FretPosition | null>(() => {
+    if (!currentTarget) return null;
+    const targetMidi = Note.midi(currentTarget);
+    if (targetMidi == null) return null;
+    // Prefer exact midi match, else any position with same pc closest in range
+    let best: FretPosition | null = null;
+    let bestDist = Infinity;
+    for (const p of positions) {
+      const m = Note.midi(p.note);
+      if (m == null) continue;
+      if (m === targetMidi) return p;
+      if (p.pitchClass === Note.pitchClass(currentTarget)) {
+        const d = Math.abs(m - targetMidi);
+        if (d < bestDist) {
+          bestDist = d;
+          best = p;
+        }
+      }
+    }
+    return best;
+  }, [currentTarget, positions]);
+
+  // Detected pitch (stable reference)
+  const detectedPc = pitch?.detected ? pitch.pitchClass : null;
+  const isInScale = detectedPc ? isPitchClassInScale(detectedPc, scale.pitchClasses) : false;
+
+  // Advance guided progress when the detected pitch (from the external audio
+  // stream) matches the current target. The audio pipeline is an external
+  // system, so an effect is appropriate here.
+  const lastAdvanceRef = useRef<{ pc: string; idx: number } | null>(null);
+  useEffect(() => {
+    if (!isGuided || !currentTargetPc || !detectedPc) return;
+    if (detectedPc !== currentTargetPc) return;
+    const last = lastAdvanceRef.current;
+    if (last && last.pc === detectedPc && last.idx === seqIndex) return;
+    lastAdvanceRef.current = { pc: detectedPc, idx: seqIndex };
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setHitCount((c) => c + 1);
+    setSeqIndex((i) => (i + 1) % sequence.length);
+  }, [detectedPc, currentTargetPc, isGuided, seqIndex, sequence.length]);
+
+  return (
+    <div
+      style={{
+        padding: isDesktop ? "24px 32px" : "16px 12px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
+      <Card style={{ padding: 16 }}>
+        <SectionLabel>スケール設定</SectionLabel>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: isDesktop ? "1fr 1fr 1fr" : "1fr",
+            gap: 12,
+            marginTop: 8,
+          }}
+        >
+          <LabeledSelect
+            label="キー"
+            value={keyRoot}
+            onChange={(v) => setKeyRoot(v as Key)}
+            options={KEYS.map((k) => ({ value: k, label: k }))}
+          />
+          <LabeledSelect
+            label="スケール"
+            value={scaleType}
+            onChange={(v) => setScaleType(v as ScaleTypeId)}
+            options={SCALE_TYPES.map((s) => ({ value: s.id, label: s.label }))}
+          />
+          <LabeledSelect
+            label="ポジション"
+            value={position}
+            onChange={(v) => setPosition(v as PositionPreset)}
+            options={(Object.keys(POSITION_RANGES) as PositionPreset[]).map(
+              (k) => ({ value: k, label: POSITION_RANGES[k].label }),
+            )}
+          />
+        </div>
+        <div
+          style={{
+            marginTop: 12,
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 8,
+            alignItems: "center",
+          }}
+        >
+          <span style={{ font: "500 13px/1 Roboto, sans-serif", color: "var(--md-on-surface-variant)" }}>
+            構成音:
+          </span>
+          {scale.pitchClasses.map((pc) => (
+            <span
+              key={pc}
+              style={{
+                padding: "4px 10px",
+                borderRadius: 12,
+                background:
+                  pc === scale.pitchClasses[0]
+                    ? "var(--md-primary-container)"
+                    : "var(--md-secondary-container)",
+                color:
+                  pc === scale.pitchClasses[0]
+                    ? "var(--md-on-primary-container)"
+                    : "var(--md-on-secondary-container)",
+                font: "500 12px/1 Roboto, sans-serif",
+              }}
+            >
+              {pc}
+            </span>
+          ))}
+        </div>
+      </Card>
+
+      <Fretboard
+        positions={positions}
+        rootPitchClass={scale.pitchClasses[0]}
+        startFret={start}
+        endFret={end}
+        highlightPosition={isGuided ? targetFretPos : null}
+        detectedPitchClass={detectedPc}
+      />
+
+      <Card style={{ padding: 16 }}>
+        <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+          {isGuided ? (
+            <OutlinedButton label="ガイド終了" onClick={() => setIsGuided(false)} />
+          ) : (
+            <FilledButton label="ガイド開始 (上行→下行)" onClick={() => setIsGuided(true)} />
+          )}
+          {isGuided && (
+            <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+              <Stat label="次の音" value={currentTarget ?? "-"} accent />
+              <Stat label="進捗" value={`${seqIndex + 1} / ${sequence.length}`} />
+              <Stat label="ヒット" value={String(hitCount)} />
+            </div>
+          )}
+        </div>
+        <div style={{ marginTop: 12, display: "flex", gap: 16, flexWrap: "wrap" }}>
+          <Stat
+            label="検出中"
+            value={pitch?.detected ? pitch.note : "-"}
+          />
+          <Stat
+            label="判定"
+            value={
+              !detectedPc ? "-" : isInScale ? "✅ スケール内" : "❌ スケール外"
+            }
+            accent={isInScale}
+          />
+        </div>
+      </Card>
+
+      <AudioSetup
+        isListening={audio.isListening}
+        isPermissionGranted={audio.isPermissionGranted}
+        inputLevel={audio.inputLevel}
+        availableDevices={audio.availableDevices}
+        selectedDeviceId={audio.selectedDeviceId}
+        error={audio.error}
+        onStart={audio.start}
+        onStop={audio.stop}
+        onSwitchDevice={audio.switchDevice}
+      />
+    </div>
+  );
+}
+
+interface LabeledSelectProps<T extends string> {
+  label: string;
+  value: T;
+  onChange: (v: T) => void;
+  options: { value: T; label: string }[];
+}
+
+function LabeledSelect<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+}: LabeledSelectProps<T>) {
+  return (
+    <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <span
+        style={{
+          font: "500 12px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+        }}
+      >
+        {label}
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as T)}
+        style={{
+          padding: "10px 12px",
+          borderRadius: 12,
+          background: "var(--md-surface-container-high)",
+          color: "var(--md-on-surface)",
+          border: "1px solid var(--md-outline-variant)",
+          font: "400 14px/1.2 Roboto, sans-serif",
+        }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <span
+        style={{
+          font: "500 11px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+          textTransform: "uppercase",
+          letterSpacing: 0.6,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          font: "600 18px/1.2 Roboto, sans-serif",
+          color: accent ? "var(--md-primary)" : "var(--md-on-surface)",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/src/pages/ScalePracticePage.tsx
+++ b/src/pages/ScalePracticePage.tsx
@@ -13,6 +13,7 @@ import {
   getScaleFretPositions,
   isPitchClassInScale,
   buildAscDescSequence,
+  normalizePitchClass,
   type Key,
   type ScaleTypeId,
 } from "../lib/music/scales";
@@ -62,7 +63,9 @@ export function ScalePracticePage() {
   }, [keyRoot, scaleType, position, isGuided]);
 
   const currentTarget = isGuided ? sequence[seqIndex] : undefined;
-  const currentTargetPc = currentTarget ? Note.pitchClass(currentTarget) : undefined;
+  const currentTargetPc = currentTarget
+    ? normalizePitchClass(Note.pitchClass(currentTarget))
+    : undefined;
   const targetFretPos = useMemo<FretPosition | null>(() => {
     if (!currentTarget) return null;
     const targetMidi = Note.midi(currentTarget);
@@ -85,24 +88,43 @@ export function ScalePracticePage() {
     return best;
   }, [currentTarget, positions]);
 
-  // Detected pitch (stable reference)
-  const detectedPc = pitch?.detected ? pitch.pitchClass : null;
-  const isInScale = detectedPc ? isPitchClassInScale(detectedPc, scale.pitchClasses) : false;
+  // Detected pitch (normalized to sharp convention for reliable comparison)
+  const detectedPcRaw = pitch?.detected ? pitch.pitchClass : null;
+  const detectedPc = detectedPcRaw ? normalizePitchClass(detectedPcRaw) : null;
+  const isInScale = detectedPc
+    ? isPitchClassInScale(detectedPc, scale.pitchClasses)
+    : false;
 
   // Advance guided progress when the detected pitch (from the external audio
   // stream) matches the current target. The audio pipeline is an external
   // system, so an effect is appropriate here.
-  const lastAdvanceRef = useRef<{ pc: string; idx: number } | null>(null);
+  //
+  // 連続して同じピッチクラスがターゲットになる場合 (例: 上行→下行で C,B,A... の
+  // 折返し付近) に一度の発音で複数ステップ進んでしまわないよう、進行後は
+  // 「音が途切れる」か「別のピッチクラスが検出される」までアーム解除する。
+  const armedRef = useRef(true);
   useEffect(() => {
-    if (!isGuided || !currentTargetPc || !detectedPc) return;
+    if (!isGuided) {
+      armedRef.current = true;
+      return;
+    }
+    if (!detectedPc) {
+      // 音が切れた → 次の発音を受け付ける
+      armedRef.current = true;
+      return;
+    }
+    if (!currentTargetPc) return;
+    if (!armedRef.current) {
+      // アーム解除中: 違うピッチクラスに変わったら再アーム
+      if (detectedPc !== currentTargetPc) armedRef.current = true;
+      return;
+    }
     if (detectedPc !== currentTargetPc) return;
-    const last = lastAdvanceRef.current;
-    if (last && last.pc === detectedPc && last.idx === seqIndex) return;
-    lastAdvanceRef.current = { pc: detectedPc, idx: seqIndex };
+    armedRef.current = false;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setHitCount((c) => c + 1);
     setSeqIndex((i) => (i + 1) % sequence.length);
-  }, [detectedPc, currentTargetPc, isGuided, seqIndex, sequence.length]);
+  }, [detectedPc, currentTargetPc, isGuided, sequence.length]);
 
   return (
     <div


### PR DESCRIPTION
Closes #44

## 概要
キー × スケールを選択して指板上の構成音を確認しながら練習できる「スケール練習モード」を実装しました。

## 実装内容
- 12キー × 7種類のスケール (Major / Natural Minor / Major Pentatonic / Minor Pentatonic / Blues / Dorian / Mixolydian)
- 4弦ベース指板図 (`src/components/scale/Fretboard.tsx`) で構成音をドット表示。ルート音はプライマリカラー、それ以外はセカンダリカラー、インレイ (3/5/7/9/12…) も描画
- ポジション切替: ローポジション (0-7) / ハイポジション (5-12)
- ガイドモード: 上行→下行の1オクターブ分のターゲットシーケンスを生成し、マイクで検出したピッチが一致したら自動で次へ進む (ヒット数カウント付き)
- リアルタイム判定: 検出中のピッチがスケール内/外かをチップ表示
- ホーム画面にエントリーポイントを追加

## アーキテクチャ
CLAUDE.md の方針通り、ロジックは `src/lib/music/scales.ts` にピュア関数として分離し、`tonal` の `Scale.get` / `Note.fromMidiSharps` / `Note.pitchClass` を活用。フラット表記 (Bb) ↔ シャープ表記 (A#) の違いを MIDI 経由で正規化することで一致判定を安定させています。

## テスト
`src/lib/music/scales.test.ts` で以下をカバー:
- スケール構成音の取得 (C major / A minor pentatonic)
- エンハーモニック等価な判定 (F major の Bb ≡ A#)
- 指板ポジション生成
- 上行→下行シーケンス生成 (1オクターブ)

## 動作確認
- `npm run lint` ✅
- `npm run build` ✅ (型チェック通過)
- `npx vitest run` ✅ 191 tests pass (既存含む)
- プレビューでホーム → スケール練習画面の描画を確認済み