### PR TITLE
feat(rhythm): リズムパターン練習モード (#45)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TunerPage } from "./pages/TunerPage";
 import { TabPracticePage } from "./pages/TabPracticePage";
 import { EditorPage } from "./pages/EditorPage";
 import { ScalePracticePage } from "./pages/ScalePracticePage";
+import { RhythmPracticePage } from "./pages/RhythmPracticePage";
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         <Route path="/editor" element={<EditorPage />} />
         <Route path="/editor/:id" element={<EditorPage />} />
         <Route path="/practice/scale" element={<ScalePracticePage />} />
+        <Route path="/practice/rhythm" element={<RhythmPracticePage />} />
       </Route>
     </Routes>
   );

--- a/src/components/practice/RhythmPatternDisplay.tsx
+++ b/src/components/practice/RhythmPatternDisplay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { RhythmPattern } from "../../types/rhythm";
-import type { TimingEvent } from "../../types/practice";
+import type { HitTimingEvent, TimingEvent } from "../../types/practice";
 import { Card } from "../md3";
 
 interface RhythmPatternDisplayProps {
@@ -190,11 +190,10 @@ export function RhythmPatternDisplay({
             strokeWidth={1}
           />
           {timingEvents
-            .filter((e) => e.judgment !== "miss")
+            .filter((e): e is HitTimingEvent => e.judgment !== "miss")
             .map((e, i) => {
               const x = beatToX(e.targetBeat);
-              const delta = (e as { deltaMs: number }).deltaMs;
-              const offsetY = Math.max(-20, Math.min(20, (delta / 100) * 20));
+              const offsetY = Math.max(-20, Math.min(20, (e.deltaMs / 100) * 20));
               const color =
                 e.judgment === "hit"
                   ? "#4ecdc4"

--- a/src/components/practice/RhythmPatternDisplay.tsx
+++ b/src/components/practice/RhythmPatternDisplay.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { RhythmPattern } from "../../types/rhythm";
+import type { TimingEvent } from "../../types/practice";
+import { Card } from "../md3";
+
+interface RhythmPatternDisplayProps {
+  pattern: RhythmPattern;
+  currentBeat: number; // fractional beat within the full pattern (from metronome)
+  isPlaying: boolean;
+  timingEvents: TimingEvent[];
+  loop: number;
+}
+
+const CELL_W_BASE = 36;
+const ROW_H = 96;
+const LEFT_PAD = 12;
+const RIGHT_PAD = 12;
+
+/**
+ * Visual rhythm notation: one circle per onset step, rest symbols, accent
+ * markers, beat labels (1 e & a), current-beat highlight, and a timing
+ * scatter showing each attempt's delta-ms from the target.
+ */
+export function RhythmPatternDisplay({
+  pattern,
+  currentBeat,
+  isPlaying,
+  timingEvents,
+  loop,
+}: RhythmPatternDisplayProps) {
+  const { steps, timeSignature, measures, subdivision } = pattern;
+  const totalBeats = timeSignature.beatsPerMeasure * measures;
+
+  // Use the finest subdivision as column unit so triplet shuffle still fits.
+  const unit = 1 / Math.max(subdivision, 2);
+  const columnCount = Math.ceil(totalBeats / unit);
+  const cellW = columnCount > 32 ? CELL_W_BASE * 0.75 : CELL_W_BASE;
+  const svgW = LEFT_PAD + columnCount * cellW + RIGHT_PAD;
+  const svgH = ROW_H + 60;
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!isPlaying || currentBeat < 0 || !scrollRef.current) return;
+    const x = LEFT_PAD + (currentBeat / unit) * cellW - 80;
+    scrollRef.current.scrollTo({ left: Math.max(0, x), behavior: "smooth" });
+  }, [currentBeat, isPlaying, cellW, unit]);
+
+  // Latest event per target beat (within current loop window of display).
+  const latestEventByBeat = useMemo(() => {
+    const map = new Map<number, TimingEvent>();
+    for (const e of timingEvents) {
+      map.set(e.targetBeat, e);
+    }
+    return map;
+  }, [timingEvents]);
+
+  const beatToX = (beat: number) => LEFT_PAD + (beat / unit) * cellW + cellW / 2;
+  const cursorX = isPlaying && currentBeat >= 0 ? beatToX(currentBeat) : null;
+
+  const stepRowY = 48;
+  const timelineY = ROW_H + 28;
+
+  return (
+    <Card style={{ padding: "16px 0 8px" }}>
+      <div
+        style={{
+          font: "500 11px/1 Roboto, sans-serif",
+          color: "var(--md-on-surface-variant)",
+          letterSpacing: 1.2,
+          textTransform: "uppercase",
+          padding: "0 16px",
+          marginBottom: 8,
+          display: "flex",
+          justifyContent: "space-between",
+        }}
+      >
+        <span>リズムパターン</span>
+        <span>LOOP {loop + 1}</span>
+      </div>
+
+      <div ref={scrollRef} style={{ overflowX: "auto", paddingBottom: 4 }}>
+        <svg width={svgW} height={svgH} style={{ display: "block" }}>
+          {/* Measure separators & beat gridlines */}
+          {Array.from({ length: totalBeats + 1 }, (_, b) => {
+            const x = LEFT_PAD + (b / unit) * cellW;
+            const isBar = b % timeSignature.beatsPerMeasure === 0;
+            return (
+              <line
+                key={`grid-${b}`}
+                x1={x}
+                x2={x}
+                y1={24}
+                y2={ROW_H}
+                stroke={isBar ? "var(--md-outline)" : "var(--md-outline-variant)"}
+                strokeWidth={isBar ? 1.5 : 1}
+              />
+            );
+          })}
+
+          {/* Beat number labels across the top */}
+          {Array.from({ length: totalBeats }, (_, b) => {
+            const x = LEFT_PAD + (b / unit) * cellW + 4;
+            return (
+              <text
+                key={`beatlabel-${b}`}
+                x={x}
+                y={18}
+                fill="var(--md-on-surface-variant)"
+                style={{ font: "500 11px Roboto, sans-serif" }}
+              >
+                {(b % timeSignature.beatsPerMeasure) + 1}
+              </text>
+            );
+          })}
+
+          {/* Current-beat highlight */}
+          {cursorX !== null && (
+            <line
+              x1={cursorX}
+              x2={cursorX}
+              y1={24}
+              y2={ROW_H}
+              stroke="var(--md-primary)"
+              strokeWidth={2}
+            />
+          )}
+
+          {/* Steps */}
+          {steps.map((step, i) => {
+            const x = beatToX(step.beat);
+            const evt = latestEventByBeat.get(step.beat);
+            let fill = "var(--md-primary)";
+            let stroke = "var(--md-primary)";
+            if (step.rest) {
+              fill = "transparent";
+              stroke = "var(--md-outline)";
+            } else if (evt) {
+              if (evt.judgment === "hit") fill = "#4ecdc4";
+              else if (evt.judgment === "early") fill = "#f9a825";
+              else if (evt.judgment === "late") fill = "#ff7043";
+              else if (evt.judgment === "miss") fill = "#ef5350";
+            }
+            return (
+              <g key={`step-${i}`}>
+                {step.rest ? (
+                  <text
+                    x={x}
+                    y={stepRowY + 6}
+                    textAnchor="middle"
+                    fill="var(--md-on-surface-variant)"
+                    style={{ font: "300 20px Roboto, sans-serif" }}
+                  >
+                    ‖
+                  </text>
+                ) : (
+                  <circle
+                    cx={x}
+                    cy={stepRowY}
+                    r={step.accent ? 11 : 9}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={step.accent ? 3 : 1}
+                  />
+                )}
+                {step.label && (
+                  <text
+                    x={x}
+                    y={stepRowY + 28}
+                    textAnchor="middle"
+                    fill="var(--md-on-surface-variant)"
+                    style={{ font: "400 11px Roboto, sans-serif" }}
+                  >
+                    {step.label}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+
+          {/* Timing scatter (delta ms from target, ±100ms range) */}
+          <line
+            x1={LEFT_PAD}
+            x2={svgW - RIGHT_PAD}
+            y1={timelineY}
+            y2={timelineY}
+            stroke="var(--md-outline-variant)"
+            strokeWidth={1}
+          />
+          {timingEvents
+            .filter((e) => e.judgment !== "miss")
+            .map((e, i) => {
+              const x = beatToX(e.targetBeat);
+              const delta = (e as { deltaMs: number }).deltaMs;
+              const offsetY = Math.max(-20, Math.min(20, (delta / 100) * 20));
+              const color =
+                e.judgment === "hit"
+                  ? "#4ecdc4"
+                  : e.judgment === "early"
+                    ? "#f9a825"
+                    : "#ff7043";
+              return (
+                <circle
+                  key={`dot-${i}`}
+                  cx={x}
+                  cy={timelineY + offsetY}
+                  r={3}
+                  fill={color}
+                  opacity={0.85}
+                />
+              );
+            })}
+        </svg>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/practice/RhythmPatternDisplay.tsx
+++ b/src/components/practice/RhythmPatternDisplay.tsx
@@ -39,11 +39,14 @@ export function RhythmPatternDisplay({
   const svgH = ROW_H + 60;
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Only scroll when the integer beat changes — RAF-driven fractional updates
+  // would otherwise interrupt `behavior: smooth` every frame and jank.
+  const beatIndex = Math.floor(currentBeat);
   useEffect(() => {
-    if (!isPlaying || currentBeat < 0 || !scrollRef.current) return;
-    const x = LEFT_PAD + (currentBeat / unit) * cellW - 80;
+    if (!isPlaying || beatIndex < 0 || !scrollRef.current) return;
+    const x = LEFT_PAD + (beatIndex / unit) * cellW - 80;
     scrollRef.current.scrollTo({ left: Math.max(0, x), behavior: "smooth" });
-  }, [currentBeat, isPlaying, cellW, unit]);
+  }, [beatIndex, isPlaying, cellW, unit]);
 
   // Latest event per target beat (within current loop window of display).
   const latestEventByBeat = useMemo(() => {

--- a/src/data/rhythmPatterns.ts
+++ b/src/data/rhythmPatterns.ts
@@ -1,0 +1,97 @@
+import type { RhythmPattern } from "../types/rhythm";
+
+/**
+ * Generate labels "1 e & a 2 e & a ..." for 16th-note grids,
+ * or "1 & 2 & ..." for 8th-note grids.
+ */
+function labelFor(beat: number, subdivision: number, beatsPerMeasure: number): string {
+  const beatInMeasure = beat % beatsPerMeasure;
+  const beatInt = Math.floor(beatInMeasure);
+  const frac = beatInMeasure - beatInt;
+  if (subdivision === 4) {
+    const idx = Math.round(frac * 4);
+    return [`${beatInt + 1}`, "e", "&", "a"][idx] ?? "";
+  }
+  if (subdivision === 2) {
+    return frac < 0.25 ? `${beatInt + 1}` : "&";
+  }
+  return `${beatInt + 1}`;
+}
+
+export const rhythmPatterns: RhythmPattern[] = [
+  {
+    id: "eighth-straight",
+    name: "8分音符ストレート",
+    description: "表裏を等間隔で。メトロノームの「&」に遅れないように。",
+    bpm: 90,
+    timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+    measures: 2,
+    subdivision: 2,
+    steps: Array.from({ length: 16 }, (_, i) => {
+      const beat = i * 0.5;
+      return { beat, label: labelFor(beat, 2, 4) };
+    }),
+  },
+  {
+    id: "eighth-shuffle",
+    name: "8分音符シャッフル",
+    description: "3連符の1・3に乗るシャッフル。ハネすぎ・詰めすぎに注意。",
+    bpm: 90,
+    timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+    measures: 2,
+    subdivision: 2,
+    steps: Array.from({ length: 8 }, (_, i) => i).flatMap((beatInt) => [
+      { beat: beatInt, label: `${(beatInt % 4) + 1}` },
+      // Shuffle "&" lands 2/3 into the beat (last partial of a triplet).
+      { beat: beatInt + 2 / 3, label: "&" },
+    ]),
+  },
+  {
+    id: "sixteenth-straight",
+    name: "16分音符",
+    description: "4分割で正確に。右手（ピッキング）の粒を揃えよう。",
+    bpm: 70,
+    timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+    measures: 1,
+    subdivision: 4,
+    steps: Array.from({ length: 16 }, (_, i) => {
+      const beat = i * 0.25;
+      return { beat, label: labelFor(beat, 4, 4) };
+    }),
+  },
+  {
+    id: "syncopation-offbeat",
+    name: "シンコペーション",
+    description: "裏拍にアクセント。表を休符にして、裏を強く当てる感覚を鍛える。",
+    bpm: 90,
+    timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+    measures: 2,
+    subdivision: 2,
+    steps: Array.from({ length: 8 }, (_, i) => i).flatMap((beatInt) => [
+      { beat: beatInt, rest: true, label: `${(beatInt % 4) + 1}` },
+      { beat: beatInt + 0.5, accent: true, label: "&" },
+    ]),
+  },
+  {
+    id: "rest-pattern",
+    name: "休符を含むパターン",
+    description: "1・2&・4のリズム。休符でミュートする練習に。",
+    bpm: 85,
+    timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+    measures: 2,
+    subdivision: 2,
+    steps: [
+      // Per measure: hit 1, rest 1&, hit 2, hit 2&, rest 3, rest 3&, hit 4, rest 4&
+      ...[0, 4].flatMap((base) => [
+        { beat: base + 0, label: "1" },
+        { beat: base + 0.5, rest: true, label: "&" },
+        { beat: base + 1, label: "2" },
+        { beat: base + 1.5, label: "&" },
+        { beat: base + 2, rest: true, label: "3" },
+        { beat: base + 2.5, rest: true, label: "&" },
+        { beat: base + 3, label: "4" },
+        { beat: base + 3.5, rest: true, label: "&" },
+      ]),
+    ],
+  },
+];

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -35,6 +35,10 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
 
   const [phase, setPhase] = useState<TabSessionPhase>("idle");
   const [timingEvents, setTimingEvents] = useState<TimingEvent[]>([]);
+  // Events observed within the current loop only. Consumers that want a
+  // per-loop visualisation (scatter, per-step highlight) should use this
+  // instead of `timingEvents`, which accumulates across all loops.
+  const [currentLoopEvents, setCurrentLoopEvents] = useState<TimingEvent[]>([]);
   const [currentBeat, setCurrentBeat] = useState(-1);
   const [loop, setLoop] = useState(0);
   const [lastEvent, setLastEvent] = useState<TimingEvent | null>(null);
@@ -84,6 +88,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
           allEventsRef.current = [...allEventsRef.current, event];
           loopEventsRef.current = [...loopEventsRef.current, event];
           setTimingEvents((prev) => [...prev, event]);
+          setCurrentLoopEvents((prev) => [...prev, event]);
           setLastEvent(event);
         }
       }
@@ -117,6 +122,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
             allEventsRef.current = [...allEventsRef.current, ...misses];
             loopEventsRef.current = [...loopEventsRef.current, ...misses];
             setTimingEvents((prev) => [...prev, ...misses]);
+            setCurrentLoopEvents((prev) => [...prev, ...misses]);
           }
 
           // Evaluate auto-BPM at loop boundary. Pass the freshly-observed
@@ -129,6 +135,9 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
           loopEventsRef.current = [];
 
           setLoop((prev) => prev + 1);
+          // Reset per-loop events so the next loop starts with a blank
+          // visualisation (no stale hit/miss colours from the previous pass).
+          setCurrentLoopEvents([]);
         }
         hitBeatsRef.current = new Set();
         targetsRef.current = buildTimingTargets(
@@ -148,6 +157,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
   // --- Session lifecycle ---
   const startSession = useCallback(async () => {
     setTimingEvents([]);
+    setCurrentLoopEvents([]);
     setCurrentBeat(-1);
     setLoop(0);
     setLastEvent(null);
@@ -211,6 +221,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
       currentBeat,
       loop,
       timingEvents,
+      currentLoopEvents,
       lastEvent,
       stats,
       metronome: metronomeSlice,
@@ -218,6 +229,6 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
       startSession,
       stopSession,
     }),
-    [phase, currentBeat, loop, timingEvents, lastEvent, stats, metronomeSlice, autoBpm, startSession, stopSession],
+    [phase, currentBeat, loop, timingEvents, currentLoopEvents, lastEvent, stats, metronomeSlice, autoBpm, startSession, stopSession],
   );
 }

--- a/src/lib/practice/rhythmPattern.test.ts
+++ b/src/lib/practice/rhythmPattern.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { rhythmPatternToTabPreset } from "./rhythmPattern";
+import type { RhythmPattern } from "../../types/rhythm";
+
+const base: RhythmPattern = {
+  id: "t",
+  name: "t",
+  description: "",
+  bpm: 90,
+  timeSignature: { beatsPerMeasure: 4, beatUnit: 4 },
+  measures: 1,
+  subdivision: 2,
+  steps: [
+    { beat: 0, label: "1" },
+    { beat: 0.5, rest: true, label: "&" },
+    { beat: 1, accent: true, label: "2" },
+    { beat: 2, label: "3" },
+  ],
+};
+
+describe("rhythmPatternToTabPreset", () => {
+  it("drops rests and maps steps to open E onsets", () => {
+    const preset = rhythmPatternToTabPreset(base);
+    expect(preset.notes).toHaveLength(3);
+    expect(preset.notes.every((n) => n.string === 4 && n.fret === 0)).toBe(true);
+    expect(preset.notes.map((n) => n.beat)).toEqual([0, 1, 2]);
+  });
+
+  it("preserves preset metadata", () => {
+    const preset = rhythmPatternToTabPreset(base);
+    expect(preset.id).toBe("t");
+    expect(preset.bpm).toBe(90);
+    expect(preset.timeSignature).toEqual({ beatsPerMeasure: 4, beatUnit: 4 });
+    expect(preset.measures).toBe(1);
+  });
+});

--- a/src/lib/practice/rhythmPattern.ts
+++ b/src/lib/practice/rhythmPattern.ts
@@ -1,0 +1,32 @@
+import type { RhythmPattern } from "../../types/rhythm";
+import type { TabNote, TabPreset } from "../../types/practice";
+
+/**
+ * Convert a RhythmPattern to a TabPreset so it can be driven by the
+ * existing useTabPractice timing machinery.
+ *
+ * Pitch is irrelevant for rhythm practice — we map every step to the open
+ * E string (string 4, fret 0) as a canonical mute/open-string onset target.
+ * Rests are dropped (they are not timing targets). The display layer uses
+ * the original RhythmPattern, not this preset.
+ */
+export function rhythmPatternToTabPreset(pattern: RhythmPattern): TabPreset {
+  const notes: TabNote[] = pattern.steps
+    .filter((s) => !s.rest)
+    .map((s) => ({
+      string: 4,
+      fret: 0,
+      beat: s.beat,
+      label: s.label,
+    }));
+
+  return {
+    id: pattern.id,
+    name: pattern.name,
+    description: pattern.description,
+    bpm: pattern.bpm,
+    timeSignature: pattern.timeSignature,
+    measures: pattern.measures,
+    notes,
+  };
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -90,6 +90,39 @@ export function HomePage() {
         </Link>
       </div>
 
+      {/* Rhythm practice */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <SectionLabel>リズム練習</SectionLabel>
+        <Link
+          to="/practice/rhythm"
+          style={{
+            textDecoration: "none",
+            background: "var(--md-tertiary-container, var(--md-secondary-container))",
+            color: "var(--md-on-tertiary-container, var(--md-on-secondary-container))",
+            borderRadius: 16,
+            padding: "16px 18px",
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <span style={{ fontSize: 28 }}>🥁</span>
+          <span style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span style={{ font: "500 15px/1.3 Roboto, sans-serif" }}>
+              リズムパターンに特化した練習
+            </span>
+            <span
+              style={{
+                font: "400 12px/1.4 Roboto, sans-serif",
+                opacity: 0.8,
+              }}
+            >
+              8分 / 16分 / シャッフル / シンコペーション
+            </span>
+          </span>
+        </Link>
+      </div>
+
       {/* Preset list */}
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <SectionLabel>プリセット</SectionLabel>

--- a/src/pages/RhythmPracticePage.tsx
+++ b/src/pages/RhythmPracticePage.tsx
@@ -173,7 +173,7 @@ function RhythmPracticeContent({
         pattern={pattern}
         currentBeat={practice.currentBeat}
         isPlaying={practice.phase === "playing"}
-        timingEvents={practice.timingEvents}
+        timingEvents={practice.currentLoopEvents}
         loop={practice.loop}
       />
 

--- a/src/pages/RhythmPracticePage.tsx
+++ b/src/pages/RhythmPracticePage.tsx
@@ -16,7 +16,11 @@ export function RhythmPracticePage() {
     rhythmPatterns.find((p) => p.id === selectedId) ?? rhythmPatterns[0];
   const preset = useMemo(() => rhythmPatternToTabPreset(pattern), [pattern]);
 
-  // Remount practice when switching patterns so state / metronome reset.
+  // Audio is owned by the outer component so switching patterns does NOT
+  // tear down the AudioEngine / lose mic permission. Only the practice
+  // session (metronome, timing events) is remounted via `key`.
+  const audio = useAudioInput();
+
   return (
     <RhythmPracticeContent
       key={pattern.id}
@@ -25,6 +29,7 @@ export function RhythmPracticePage() {
       patterns={rhythmPatterns}
       onSelect={setSelectedId}
       selectedId={selectedId}
+      audio={audio}
     />
   );
 }
@@ -35,6 +40,7 @@ interface ContentProps {
   patterns: typeof rhythmPatterns;
   selectedId: string;
   onSelect: (id: string) => void;
+  audio: ReturnType<typeof useAudioInput>;
 }
 
 function RhythmPracticeContent({
@@ -43,8 +49,8 @@ function RhythmPracticeContent({
   patterns,
   selectedId,
   onSelect,
+  audio,
 }: ContentProps) {
-  const audio = useAudioInput();
   const practice = useTabPractice(preset, audio.engine);
   const [startError, setStartError] = useState<string | null>(null);
   const isDesktop = useMediaQuery("(min-width: 768px)");

--- a/src/pages/RhythmPracticePage.tsx
+++ b/src/pages/RhythmPracticePage.tsx
@@ -1,0 +1,230 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { rhythmPatterns } from "../data/rhythmPatterns";
+import { rhythmPatternToTabPreset } from "../lib/practice/rhythmPattern";
+import { useAudioInput } from "../hooks/useAudioInput";
+import { useTabPractice } from "../hooks/useTabPractice";
+import { useMediaQuery } from "../hooks/useMediaQuery";
+import { MetronomeControls } from "../components/practice/MetronomeControls";
+import { TimingFeedback } from "../components/practice/TimingFeedback";
+import { RhythmPatternDisplay } from "../components/practice/RhythmPatternDisplay";
+import { Card, Tag } from "../components/md3";
+
+export function RhythmPracticePage() {
+  const [selectedId, setSelectedId] = useState(rhythmPatterns[0].id);
+  const pattern =
+    rhythmPatterns.find((p) => p.id === selectedId) ?? rhythmPatterns[0];
+  const preset = useMemo(() => rhythmPatternToTabPreset(pattern), [pattern]);
+
+  // Remount practice when switching patterns so state / metronome reset.
+  return (
+    <RhythmPracticeContent
+      key={pattern.id}
+      pattern={pattern}
+      preset={preset}
+      patterns={rhythmPatterns}
+      onSelect={setSelectedId}
+      selectedId={selectedId}
+    />
+  );
+}
+
+interface ContentProps {
+  pattern: (typeof rhythmPatterns)[number];
+  preset: ReturnType<typeof rhythmPatternToTabPreset>;
+  patterns: typeof rhythmPatterns;
+  selectedId: string;
+  onSelect: (id: string) => void;
+}
+
+function RhythmPracticeContent({
+  pattern,
+  preset,
+  patterns,
+  selectedId,
+  onSelect,
+}: ContentProps) {
+  const audio = useAudioInput();
+  const practice = useTabPractice(preset, audio.engine);
+  const [startError, setStartError] = useState<string | null>(null);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const handleStart = async () => {
+    setStartError(null);
+    if (!audio.isListening) audio.start().catch(() => {});
+    try {
+      await practice.startSession();
+    } catch (err) {
+      setStartError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const displayedError = startError;
+  const micWarning = !startError && audio.error ? audio.error : null;
+
+  const errorBlock = (
+    <>
+      {displayedError && (
+        <div
+          role="alert"
+          style={{
+            background: "#ef53501a",
+            border: "1px solid #ef535066",
+            color: "#ef5350",
+            borderRadius: 12,
+            padding: "12px 16px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+          }}
+        >
+          {displayedError}
+        </div>
+      )}
+      {micWarning && (
+        <div
+          style={{
+            background: "#f9a8251a",
+            border: "1px solid #f9a82566",
+            color: "#f9a825",
+            borderRadius: 12,
+            padding: "12px 16px",
+            font: "400 13px/1.5 Roboto, sans-serif",
+          }}
+        >
+          🎤 マイクが利用できません（メトロノームは動作します）: {micWarning}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      style={{
+        padding: isDesktop ? "32px 32px" : "24px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+        <Link to="/" style={{ color: "var(--md-primary)", textDecoration: "none", font: "400 13px/1 Roboto, sans-serif" }}>
+          ← Home
+        </Link>
+        <h1 style={{ margin: 0, font: "500 22px/1.3 Roboto, sans-serif", color: "var(--md-on-surface)" }}>
+          リズム練習
+        </h1>
+        <span style={{ font: "400 13px/1.4 Roboto, sans-serif", color: "var(--md-on-surface-variant)" }}>
+          ピッチ不問、オンセットのタイミングのみを評価
+        </span>
+      </div>
+
+      <Card style={{ padding: 16 }}>
+        <div
+          style={{
+            font: "500 11px/1 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+            letterSpacing: 1.2,
+            textTransform: "uppercase",
+            marginBottom: 12,
+          }}
+        >
+          パターン
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {patterns.map((p) => {
+            const active = p.id === selectedId;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => onSelect(p.id)}
+                style={{
+                  border: "1px solid",
+                  borderColor: active ? "var(--md-primary)" : "var(--md-outline-variant)",
+                  background: active ? "var(--md-primary-container)" : "transparent",
+                  color: active ? "var(--md-on-primary-container)" : "var(--md-on-surface)",
+                  borderRadius: 20,
+                  padding: "8px 14px",
+                  font: "500 13px/1 Roboto, sans-serif",
+                  cursor: "pointer",
+                }}
+              >
+                {p.name}
+              </button>
+            );
+          })}
+        </div>
+        <p
+          style={{
+            margin: "12px 0 0",
+            font: "400 13px/1.5 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          {pattern.description}
+        </p>
+        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+          <Tag label={`${pattern.timeSignature.beatsPerMeasure}/${pattern.timeSignature.beatUnit}`} />
+          <Tag label={`${pattern.measures} 小節`} />
+          <Tag label={pattern.subdivision === 4 ? "16分グリッド" : "8分グリッド"} />
+        </div>
+      </Card>
+
+      <RhythmPatternDisplay
+        pattern={pattern}
+        currentBeat={practice.currentBeat}
+        isPlaying={practice.phase === "playing"}
+        timingEvents={practice.timingEvents}
+        loop={practice.loop}
+      />
+
+      {isDesktop ? (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 16,
+            alignItems: "start",
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <MetronomeControls
+              bpm={practice.metronome.bpm}
+              isPlaying={practice.metronome.isPlaying}
+              phase={practice.phase}
+              onBpmChange={practice.metronome.setBpm}
+              onStart={handleStart}
+              onStop={practice.stopSession}
+            />
+            {errorBlock}
+          </div>
+          <TimingFeedback
+            lastEvent={practice.lastEvent}
+            stats={practice.stats}
+            phase={practice.phase}
+            timingEvents={practice.timingEvents}
+            loop={practice.loop}
+          />
+        </div>
+      ) : (
+        <>
+          <MetronomeControls
+            bpm={practice.metronome.bpm}
+            isPlaying={practice.metronome.isPlaying}
+            phase={practice.phase}
+            onBpmChange={practice.metronome.setBpm}
+            onStart={handleStart}
+            onStop={practice.stopSession}
+          />
+          {errorBlock}
+          <TimingFeedback
+            lastEvent={practice.lastEvent}
+            stats={practice.stats}
+            phase={practice.phase}
+            timingEvents={practice.timingEvents}
+            loop={practice.loop}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/types/rhythm.ts
+++ b/src/types/rhythm.ts
@@ -1,0 +1,26 @@
+import type { TimeSignature } from "./practice";
+
+/**
+ * A single step in a rhythm pattern.
+ * `beat` is expressed in quarter-note units relative to the pattern start
+ * (e.g. 0, 0.5, 1, 1.5... for straight eighths; 0, 0.667, 1, 1.667 for shuffle).
+ */
+export interface RhythmStep {
+  beat: number;
+  rest?: boolean;
+  accent?: boolean;
+  /** Display label shown under the step (e.g. "1", "&", "e", "a"). */
+  label?: string;
+}
+
+export interface RhythmPattern {
+  id: string;
+  name: string;
+  description: string;
+  bpm: number;
+  timeSignature: TimeSignature;
+  measures: number;
+  /** Grid subdivision used for display (e.g. 2 = eighths, 4 = sixteenths). */
+  subdivision: number;
+  steps: RhythmStep[];
+}


### PR DESCRIPTION
Closes #45

## 概要
ピッチを無視し、タイミング（リズム）の正確さだけを鍛える練習モードを追加。

## 変更点
- 新しい型 `RhythmPattern` / `RhythmStep`（`src/types/rhythm.ts`）
- `rhythmPatternToTabPreset` で既存の `TabPreset` 型に変換 → `useTabPractice` / `onsetDetector` / `timingEvaluator` / `MetronomeEngine` をそのまま流用（すべての音は開放E固定、休符はターゲットから除外）
- 視覚的ノーテーション `RhythmPatternDisplay`: ●/休符記号、アクセント○太枠、拍ラベル（1 e & a）、メトロノームに同期したカーソル、±100msのタイミング散布図
- プリセット5種: 8分ストレート / 8分シャッフル（3連2分割） / 16分 / シンコペーション（裏アクセント） / 休符含み
- ルート `/practice/rhythm`、HomePageにエントリーカード追加

## テスト
- `rhythmPattern.test.ts`: 休符除外・open E マッピング・メタデータ保持
- 既存194テストすべてpass、lint clean、build OK