### PR TITLE
feat: 音程の正確さ判定をタブ譜練習に追加 (#46)

### DIFF
--- a/src/components/practice/TimingFeedback.tsx
+++ b/src/components/practice/TimingFeedback.tsx
@@ -7,7 +7,13 @@ import { Card } from "../md3";
 
 interface TimingFeedbackProps {
   lastEvent: TimingEvent | null;
-  stats: { hitRate: number; avgAbsDeltaMs: number };
+  stats: {
+    hitRate: number;
+    avgAbsDeltaMs: number;
+    pitchAccuracy: number;
+    avgAbsCents: number;
+    pitchJudgedCount: number;
+  };
   phase: TabSessionPhase;
   timingEvents: TimingEvent[];
   loop: number;
@@ -18,6 +24,8 @@ const JUDGMENT_CONFIG: Record<
   { label: string; color: string; bg: string }
 > = {
   hit: { label: "HIT", color: "#4ecdc4", bg: "#4ecdc41a" },
+  perfect: { label: "PERFECT", color: "#66ffcc", bg: "#66ffcc22" },
+  "timing-only": { label: "TIMING", color: "#ffb74d", bg: "#ffb74d1a" },
   early: { label: "EARLY", color: "#f9a825", bg: "#f9a8251a" },
   late: { label: "LATE", color: "#ff7043", bg: "#ff70431a" },
   miss: { label: "MISS", color: "#ef5350", bg: "#ef53501a" },
@@ -91,15 +99,26 @@ export function TimingFeedback({
                 {cfg.label}
               </div>
 
-              {lastEvent.judgment !== "miss" && lastEvent.deltaMs !== 0 && (
+              {lastEvent.judgment !== "miss" && (
                 <div
                   style={{
-                    font: "400 14px/1 Roboto Mono, monospace",
+                    font: "400 14px/1.3 Roboto Mono, monospace",
                     color: "var(--md-on-surface-variant)",
+                    textAlign: "center",
                   }}
                 >
-                  {lastEvent.deltaMs > 0 ? "+" : ""}
-                  {lastEvent.deltaMs}ms
+                  {lastEvent.deltaMs !== 0 && (
+                    <>
+                      {lastEvent.deltaMs > 0 ? "+" : ""}
+                      {lastEvent.deltaMs}ms
+                    </>
+                  )}
+                  {lastEvent.pitchCents != null && (
+                    <div>
+                      {lastEvent.pitchCents > 0 ? "+" : ""}
+                      {lastEvent.pitchCents}¢
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -249,8 +268,69 @@ export function TimingFeedback({
                 </div>
               </div>
             </div>
+            {stats.pitchJudgedCount > 0 && (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gap: 16,
+                  marginBottom: 16,
+                }}
+              >
+                <div
+                  style={{
+                    background: "var(--md-surface-container)",
+                    borderRadius: 12,
+                    padding: 16,
+                  }}
+                >
+                  <div
+                    style={{
+                      font: "700 32px/1 Roboto, sans-serif",
+                      color: "#66ffcc",
+                    }}
+                  >
+                    {Math.round(stats.pitchAccuracy * 100)}%
+                  </div>
+                  <div
+                    style={{
+                      font: "400 12px/1 Roboto, sans-serif",
+                      color: "var(--md-on-surface-variant)",
+                      marginTop: 4,
+                    }}
+                  >
+                    Pitch Accuracy
+                  </div>
+                </div>
+                <div
+                  style={{
+                    background: "var(--md-surface-container)",
+                    borderRadius: 12,
+                    padding: 16,
+                  }}
+                >
+                  <div
+                    style={{
+                      font: "700 32px/1 Roboto, sans-serif",
+                      color: "var(--md-on-surface)",
+                    }}
+                  >
+                    {stats.avgAbsCents}¢
+                  </div>
+                  <div
+                    style={{
+                      font: "400 12px/1 Roboto, sans-serif",
+                      color: "var(--md-on-surface-variant)",
+                      marginTop: 4,
+                    }}
+                  >
+                    Avg Cents
+                  </div>
+                </div>
+              </div>
+            )}
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              {(["hit", "early", "late", "miss"] as TimingJudgment[]).map(
+              {(["perfect", "timing-only", "hit", "early", "late", "miss"] as TimingJudgment[]).map(
                 (j) => {
                   const count = timingEvents.filter(
                     (e) => e.judgment === j,

--- a/src/hooks/useAutoBpm.test.ts
+++ b/src/hooks/useAutoBpm.test.ts
@@ -10,6 +10,9 @@ function makeHit(beat: number, deltaMs = 10): HitTimingEvent {
     onsetTimeMs: beat * 500 + deltaMs,
     deltaMs,
     judgment: "hit",
+    expectedFrequency: null,
+    detectedFrequency: null,
+    pitchCents: null,
   };
 }
 

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -1,5 +1,10 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import type { TabPreset, TimingEvent, TabSessionPhase } from "../types/practice";
+import type {
+  TabPreset,
+  TimingEvent,
+  TabSessionPhase,
+  HitTimingEvent,
+} from "../types/practice";
 import type { AudioEngine } from "../lib/audio/AudioEngine";
 import { OnsetDetector } from "../lib/audio/onsetDetector";
 import {
@@ -9,10 +14,32 @@ import {
   computeStats,
 } from "../lib/practice/timingEvaluator";
 import type { TimingTarget } from "../lib/practice/timingEvaluator";
+import { judgePitch } from "../lib/practice/pitchEvaluator";
 import { useMetronome } from "./useMetronome";
 import { useAutoBpm } from "./useAutoBpm";
 
-export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | null) {
+export interface PitchJudgeConfig {
+  enabled: boolean;
+  toleranceCents: number;
+}
+
+/** Window after an onset during which we keep sampling pitch for its best estimate. */
+const PITCH_SAMPLE_WINDOW_MS = 120;
+/** Ignore initial ms of the onset's attack where pitch detection is unstable. */
+const PITCH_ATTACK_SKIP_MS = 20;
+
+interface PendingPitchSample {
+  event: HitTimingEvent;
+  onsetTimeMs: number;
+  bestFrequency: number | null;
+  bestClarity: number;
+}
+
+export function useTabPractice(
+  preset: TabPreset,
+  audioEngine: AudioEngine | null,
+  pitchJudge: PitchJudgeConfig = { enabled: true, toleranceCents: 50 },
+) {
   const metronome = useMetronome(
     preset.bpm,
     preset.timeSignature.beatsPerMeasure,
@@ -50,6 +77,44 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
   const allEventsRef = useRef<TimingEvent[]>([]);
   const loopEventsRef = useRef<TimingEvent[]>([]);
   const phaseRef = useRef<TabSessionPhase>("idle");
+  const pendingPitchRef = useRef<PendingPitchSample[]>([]);
+  const pitchJudgeRef = useRef(pitchJudge);
+
+  // Replace a pending hit event with one that now carries pitch info.
+  // Stored in a ref so the RAF loop always invokes the latest closure
+  // (accessing up-to-date state setters) without extra dependencies.
+  const finalizePitchSampleRef = useRef<(s: PendingPitchSample) => void>(
+    () => {},
+  );
+  useEffect(() => {
+    finalizePitchSampleRef.current = (sample: PendingPitchSample) => {
+      const cfg = pitchJudgeRef.current;
+      const result = judgePitch(
+        sample.bestFrequency,
+        sample.event.expectedFrequency,
+        cfg.toleranceCents,
+      );
+
+      // If original already escalated to early/late, keep that judgment;
+      // only "hit" (on-time) is split into perfect / timing-only.
+      const updated: HitTimingEvent = { ...sample.event };
+      updated.detectedFrequency = sample.bestFrequency;
+      updated.pitchCents = result?.pitchCents ?? null;
+      if (sample.event.judgment === "hit" && result != null) {
+        updated.judgment = result.correct ? "perfect" : "timing-only";
+      }
+
+      const replace = (e: TimingEvent) => (e === sample.event ? updated : e);
+      allEventsRef.current = allEventsRef.current.map(replace);
+      loopEventsRef.current = loopEventsRef.current.map(replace);
+      setTimingEvents((prev) => prev.map(replace));
+      setCurrentLoopEvents((prev) => prev.map(replace));
+      setLastEvent((prev) => (prev === sample.event ? updated : prev));
+    };
+  });
+  useEffect(() => {
+    pitchJudgeRef.current = pitchJudge;
+  }, [pitchJudge]);
 
   useEffect(() => {
     phaseRef.current = phase;
@@ -90,7 +155,44 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
           setTimingEvents((prev) => [...prev, event]);
           setCurrentLoopEvents((prev) => [...prev, event]);
           setLastEvent(event);
+
+          // Queue for post-onset pitch sampling. Pitch right at the attack
+          // is noisy, so we skip the first few ms and keep the highest-clarity
+          // result across the sampling window.
+          if (pitchJudgeRef.current.enabled && event.expectedFrequency != null) {
+            pendingPitchRef.current = [
+              ...pendingPitchRef.current,
+              {
+                event,
+                onsetTimeMs: timeMs,
+                bestFrequency: null,
+                bestClarity: 0,
+              },
+            ];
+          }
         }
+      }
+
+      // Process pending pitch samples: update best candidate and finalize
+      // when the sampling window has elapsed.
+      if (pendingPitchRef.current.length > 0) {
+        const remaining: PendingPitchSample[] = [];
+        for (const sample of pendingPitchRef.current) {
+          const elapsed = timeMs - sample.onsetTimeMs;
+          if (elapsed >= PITCH_ATTACK_SKIP_MS && elapsed < PITCH_SAMPLE_WINDOW_MS) {
+            const p = audioEngine.detectPitch();
+            if (p.detected && p.clarity > sample.bestClarity) {
+              sample.bestClarity = p.clarity;
+              sample.bestFrequency = p.frequency;
+            }
+          }
+          if (elapsed >= PITCH_SAMPLE_WINDOW_MS) {
+            finalizePitchSampleRef.current(sample);
+          } else {
+            remaining.push(sample);
+          }
+        }
+        pendingPitchRef.current = remaining;
       }
 
       animFrameRef.current = requestAnimationFrame(() =>
@@ -165,6 +267,7 @@ export function useTabPractice(preset: TabPreset, audioEngine: AudioEngine | nul
     loopEventsRef.current = [];
     hitBeatsRef.current = new Set();
     targetsRef.current = [];
+    pendingPitchRef.current = [];
     onsetDetectorRef.current.reset();
     autoBpmRef.current.resetSession(metronomeRef.current.bpm);
 

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -159,7 +159,14 @@ export function useTabPractice(
           // Queue for post-onset pitch sampling. Pitch right at the attack
           // is noisy, so we skip the first few ms and keep the highest-clarity
           // result across the sampling window.
-          if (pitchJudgeRef.current.enabled && event.expectedFrequency != null) {
+          // Only "hit" (on-time) is eligible for pitch evaluation; early/late
+          // are excluded so pitchAccuracy stats stay consistent with the
+          // "成功判定の中での音程精度" semantics (see PR #52 comment).
+          if (
+            pitchJudgeRef.current.enabled &&
+            event.expectedFrequency != null &&
+            event.judgment === "hit"
+          ) {
             pendingPitchRef.current = [
               ...pendingPitchRef.current,
               {

--- a/src/lib/practice/pitchEvaluator.test.ts
+++ b/src/lib/practice/pitchEvaluator.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  BASS_OPEN_STRING_MIDI,
+  midiToFrequency,
+  expectedFrequencyForNote,
+  centsBetween,
+  foldCentsToPitchClass,
+  judgePitch,
+} from "./pitchEvaluator";
+
+describe("midiToFrequency", () => {
+  it("A4 = 440Hz", () => {
+    expect(midiToFrequency(69)).toBeCloseTo(440, 3);
+  });
+  it("E1 ≈ 41.2Hz", () => {
+    expect(midiToFrequency(28)).toBeCloseTo(41.2, 1);
+  });
+});
+
+describe("expectedFrequencyForNote", () => {
+  it("open E string (string 4, fret 0) ≈ 41.2Hz", () => {
+    expect(expectedFrequencyForNote({ string: 4, fret: 0, beat: 0 }))!
+      .toBeCloseTo(41.2, 1);
+  });
+
+  it("open A string (string 3, fret 0) ≈ 55Hz", () => {
+    expect(expectedFrequencyForNote({ string: 3, fret: 0, beat: 0 }))!
+      .toBeCloseTo(55, 1);
+  });
+
+  it("A string 5th fret = D2 (same as open D) ≈ 73.4Hz", () => {
+    const dFromA = expectedFrequencyForNote({ string: 3, fret: 5, beat: 0 });
+    const openD = expectedFrequencyForNote({ string: 2, fret: 0, beat: 0 });
+    expect(dFromA).toBeCloseTo(openD!, 3);
+    expect(dFromA).toBeCloseTo(73.4, 1);
+  });
+
+  it("open G string (string 1, fret 0) ≈ 98Hz", () => {
+    expect(expectedFrequencyForNote({ string: 1, fret: 0, beat: 0 }))!
+      .toBeCloseTo(98, 1);
+  });
+
+  it("returns null for unknown string", () => {
+    expect(expectedFrequencyForNote({ string: 9, fret: 0, beat: 0 })).toBeNull();
+  });
+
+  it("covers all 4 strings", () => {
+    expect(Object.keys(BASS_OPEN_STRING_MIDI)).toHaveLength(4);
+  });
+});
+
+describe("centsBetween", () => {
+  it("0 for identical frequencies", () => {
+    expect(centsBetween(440, 440)).toBeCloseTo(0, 6);
+  });
+  it("+1200 for one octave up", () => {
+    expect(centsBetween(880, 440)).toBeCloseTo(1200, 3);
+  });
+  it("-1200 for one octave down", () => {
+    expect(centsBetween(220, 440)).toBeCloseTo(-1200, 3);
+  });
+  it("returns null on invalid inputs", () => {
+    expect(centsBetween(0, 440)).toBeNull();
+    expect(centsBetween(440, 0)).toBeNull();
+    expect(centsBetween(-10, 440)).toBeNull();
+  });
+});
+
+describe("foldCentsToPitchClass", () => {
+  it("leaves small offsets unchanged", () => {
+    expect(foldCentsToPitchClass(30)).toBe(30);
+    expect(foldCentsToPitchClass(-30)).toBe(-30);
+  });
+  it("folds one octave up to 0", () => {
+    expect(foldCentsToPitchClass(1200)).toBe(0);
+  });
+  it("folds 1250 cents to 50", () => {
+    expect(foldCentsToPitchClass(1250)).toBeCloseTo(50, 6);
+  });
+  it("folds -1250 cents to -50", () => {
+    expect(foldCentsToPitchClass(-1250)).toBeCloseTo(-50, 6);
+  });
+});
+
+describe("judgePitch", () => {
+  const tol = 50;
+
+  it("returns null if either freq missing", () => {
+    expect(judgePitch(null, 440, tol)).toBeNull();
+    expect(judgePitch(440, null, tol)).toBeNull();
+  });
+
+  it("marks exact match correct", () => {
+    const r = judgePitch(440, 440, tol)!;
+    expect(r.correct).toBe(true);
+    expect(r.pitchCents).toBe(0);
+  });
+
+  it("marks within tolerance correct", () => {
+    const r = judgePitch(440 * Math.pow(2, 40 / 1200), 440, tol)!;
+    expect(r.correct).toBe(true);
+  });
+
+  it("marks outside tolerance incorrect", () => {
+    const r = judgePitch(440 * Math.pow(2, 80 / 1200), 440, tol)!;
+    expect(r.correct).toBe(false);
+  });
+
+  it("octave-confused detection is considered correct (pitch-class match)", () => {
+    // Pitchy often drops an octave for low bass notes.
+    const r = judgePitch(220, 440, tol)!;
+    expect(r.correct).toBe(true);
+    expect(r.pitchCents).toBe(0);
+  });
+});

--- a/src/lib/practice/pitchEvaluator.ts
+++ b/src/lib/practice/pitchEvaluator.ts
@@ -1,0 +1,80 @@
+import type { TabNote } from "../../types/practice";
+
+/**
+ * Open-string MIDI numbers for 4-string bass standard tuning.
+ * string 1 = G2 (MIDI 43, highest) ... string 4 = E1 (MIDI 28, lowest)
+ */
+export const BASS_OPEN_STRING_MIDI: Record<number, number> = {
+  1: 43, // G2
+  2: 38, // D2
+  3: 33, // A1
+  4: 28, // E1
+};
+
+const A4_FREQUENCY = 440;
+const A4_MIDI = 69;
+
+export function midiToFrequency(midi: number): number {
+  return A4_FREQUENCY * Math.pow(2, (midi - A4_MIDI) / 12);
+}
+
+/**
+ * Expected fundamental frequency for a given tab note on 4-string bass.
+ * Returns null if the string number is unknown.
+ */
+export function expectedFrequencyForNote(note: TabNote): number | null {
+  const openMidi = BASS_OPEN_STRING_MIDI[note.string];
+  if (openMidi === undefined) return null;
+  return midiToFrequency(openMidi + note.fret);
+}
+
+/**
+ * Cents between a detected frequency and an expected frequency.
+ * Positive = detected is sharp, negative = flat.
+ * If either frequency is invalid (<=0), returns null.
+ */
+export function centsBetween(
+  detectedHz: number,
+  expectedHz: number,
+): number | null {
+  if (!(detectedHz > 0) || !(expectedHz > 0)) return null;
+  return 1200 * Math.log2(detectedHz / expectedHz);
+}
+
+/**
+ * Fold a cent offset to its nearest pitch-class equivalent in [-600, 600).
+ * This lets octave-confused detections (e.g. pitchy returning half/double
+ * the intended frequency) still be recognised as correct pitch class.
+ */
+export function foldCentsToPitchClass(cents: number): number {
+  let folded = ((cents + 600) % 1200 + 1200) % 1200 - 600;
+  // Guarantee the canonical range (JS modulo on -600 edge case)
+  if (folded >= 600) folded -= 1200;
+  return folded;
+}
+
+export interface PitchJudgeResult {
+  /** signed cents offset (pitch-class folded) */
+  pitchCents: number;
+  /** true if within the tolerance window */
+  correct: boolean;
+}
+
+/**
+ * Judge a detected frequency against an expected frequency.
+ * Returns null if either frequency is missing / invalid.
+ */
+export function judgePitch(
+  detectedHz: number | null,
+  expectedHz: number | null,
+  toleranceCents: number,
+): PitchJudgeResult | null {
+  if (detectedHz == null || expectedHz == null) return null;
+  const raw = centsBetween(detectedHz, expectedHz);
+  if (raw == null) return null;
+  const folded = foldCentsToPitchClass(raw);
+  return {
+    pitchCents: Math.round(folded),
+    correct: Math.abs(folded) <= toleranceCents,
+  };
+}

--- a/src/lib/practice/pitchEvaluator.ts
+++ b/src/lib/practice/pitchEvaluator.ts
@@ -47,10 +47,9 @@ export function centsBetween(
  * the intended frequency) still be recognised as correct pitch class.
  */
 export function foldCentsToPitchClass(cents: number): number {
-  let folded = ((cents + 600) % 1200 + 1200) % 1200 - 600;
-  // Guarantee the canonical range (JS modulo on -600 edge case)
-  if (folded >= 600) folded -= 1200;
-  return folded;
+  // The double-modulo form `((x % n) + n) % n` always lands in [0, 1200),
+  // so subtracting 600 always lands in [-600, 600).
+  return ((cents + 600) % 1200 + 1200) % 1200 - 600;
 }
 
 export interface PitchJudgeResult {

--- a/src/lib/practice/timingEvaluator.test.ts
+++ b/src/lib/practice/timingEvaluator.test.ts
@@ -18,10 +18,13 @@ describe("buildTimingTargets", () => {
   it("creates targets for each unique beat", () => {
     const targets = buildTimingTargets(sampleNotes, 120, 0);
     expect(targets).toHaveLength(4);
-    expect(targets[0]).toEqual({ beat: 0, timeMs: 0 });
-    expect(targets[1]).toEqual({ beat: 1, timeMs: 500 }); // 60/120*1000 = 500ms per beat
-    expect(targets[2]).toEqual({ beat: 2, timeMs: 1000 });
-    expect(targets[3]).toEqual({ beat: 3, timeMs: 1500 });
+    expect(targets[0].beat).toBe(0);
+    expect(targets[0].timeMs).toBe(0);
+    expect(targets[1].beat).toBe(1);
+    expect(targets[1].timeMs).toBe(500); // 60/120*1000 = 500ms per beat
+    expect(targets[2].timeMs).toBe(1000);
+    expect(targets[3].timeMs).toBe(1500);
+    expect(targets[0].expectedFrequencies.length).toBeGreaterThan(0);
   });
 
   it("applies start time offset", () => {
@@ -81,8 +84,8 @@ describe("evaluateOnset", () => {
 
   it("selects the next valid target when the closest is already hit", () => {
     const closeTargets = [
-      { beat: 0, timeMs: 100 },
-      { beat: 1, timeMs: 150 },
+      { beat: 0, timeMs: 100, expectedFrequencies: [] },
+      { beat: 1, timeMs: 150, expectedFrequencies: [] },
     ];
     const event = evaluateOnset(110, closeTargets, new Set([0]));
     expect(event).not.toBeNull();
@@ -136,10 +139,16 @@ describe("generateMisses", () => {
 });
 
 describe("computeStats", () => {
+  const hitBase = {
+    expectedFrequency: null,
+    detectedFrequency: null,
+    pitchCents: null,
+  };
+
   it("computes hit rate and avg absolute delta", () => {
     const events: import("../../types/practice").TimingEvent[] = [
-      { targetBeat: 0, targetTimeMs: 0, onsetTimeMs: 10, deltaMs: 10, judgment: "hit" as const },
-      { targetBeat: 1, targetTimeMs: 500, onsetTimeMs: 460, deltaMs: -40, judgment: "early" as const },
+      { targetBeat: 0, targetTimeMs: 0, onsetTimeMs: 10, deltaMs: 10, judgment: "hit" as const, ...hitBase },
+      { targetBeat: 1, targetTimeMs: 500, onsetTimeMs: 460, deltaMs: -40, judgment: "early" as const, ...hitBase },
       { targetBeat: 2, targetTimeMs: 1000, onsetTimeMs: null, deltaMs: null, judgment: "miss" as const },
     ];
     const stats = computeStats(events);
@@ -160,5 +169,34 @@ describe("computeStats", () => {
     const stats = computeStats(events);
     expect(stats.hitRate).toBe(0);
     expect(stats.avgAbsDeltaMs).toBe(0);
+  });
+
+  it("computes pitch accuracy from perfect vs timing-only", () => {
+    const events: import("../../types/practice").TimingEvent[] = [
+      {
+        targetBeat: 0,
+        targetTimeMs: 0,
+        onsetTimeMs: 5,
+        deltaMs: 5,
+        judgment: "perfect" as const,
+        expectedFrequency: 110,
+        detectedFrequency: 110,
+        pitchCents: 0,
+      },
+      {
+        targetBeat: 1,
+        targetTimeMs: 500,
+        onsetTimeMs: 505,
+        deltaMs: 5,
+        judgment: "timing-only" as const,
+        expectedFrequency: 110,
+        detectedFrequency: 116,
+        pitchCents: 80,
+      },
+    ];
+    const stats = computeStats(events);
+    expect(stats.pitchJudgedCount).toBe(2);
+    expect(stats.pitchAccuracy).toBeCloseTo(0.5);
+    expect(stats.avgAbsCents).toBe(40); // (0 + 80) / 2
   });
 });

--- a/src/lib/practice/timingEvaluator.test.ts
+++ b/src/lib/practice/timingEvaluator.test.ts
@@ -171,6 +171,39 @@ describe("computeStats", () => {
     expect(stats.avgAbsDeltaMs).toBe(0);
   });
 
+  it("excludes early/late events from pitch accuracy even if pitchCents is present", () => {
+    // Regression: defense-in-depth. Even if an early/late event somehow
+    // carries pitchCents (e.g. future refactor), it must not affect
+    // pitchAccuracy — the stat means "タイミング正解の中での音程正解率".
+    const events: import("../../types/practice").TimingEvent[] = [
+      {
+        targetBeat: 0,
+        targetTimeMs: 0,
+        onsetTimeMs: 5,
+        deltaMs: 5,
+        judgment: "perfect" as const,
+        expectedFrequency: 110,
+        detectedFrequency: 110,
+        pitchCents: 0,
+      },
+      {
+        // early with pitchCents populated — should be ignored by pitch stats
+        targetBeat: 1,
+        targetTimeMs: 500,
+        onsetTimeMs: 450,
+        deltaMs: -50,
+        judgment: "early" as const,
+        expectedFrequency: 110,
+        detectedFrequency: 200,
+        pitchCents: 500,
+      },
+    ];
+    const stats = computeStats(events);
+    expect(stats.pitchJudgedCount).toBe(1);
+    expect(stats.pitchAccuracy).toBe(1);
+    expect(stats.avgAbsCents).toBe(0);
+  });
+
   it("computes pitch accuracy from perfect vs timing-only", () => {
     const events: import("../../types/practice").TimingEvent[] = [
       {

--- a/src/lib/practice/timingEvaluator.ts
+++ b/src/lib/practice/timingEvaluator.ts
@@ -139,7 +139,14 @@ export function computeStats(events: TimingEvent[]): TimingStats {
   const avgAbsDeltaMs =
     deltas.length > 0 ? deltas.reduce((a, b) => a + b, 0) / deltas.length : 0;
 
-  const pitchJudged = hits.filter((e) => e.pitchCents != null);
+  // Only on-time hits (perfect / timing-only) participate in pitch accuracy;
+  // early/late are excluded from both numerator and denominator so "音程
+  // 精度" reflects 「タイミング正解した中での音程正解率」.
+  const pitchJudged = hits.filter(
+    (e) =>
+      e.pitchCents != null &&
+      (e.judgment === "perfect" || e.judgment === "timing-only"),
+  );
   const pitchCorrect = pitchJudged.filter(
     (e) => e.judgment === "perfect",
   ).length;

--- a/src/lib/practice/timingEvaluator.ts
+++ b/src/lib/practice/timingEvaluator.ts
@@ -1,10 +1,18 @@
-import type { TimingEvent, TabNote, HitTimingEvent, MissTimingEvent } from "../../types/practice";
+import type {
+  TimingEvent,
+  TabNote,
+  HitTimingEvent,
+  MissTimingEvent,
+} from "../../types/practice";
+import { expectedFrequencyForNote } from "./pitchEvaluator";
 
 const HIT_WINDOW_MS = 100;
 
 export interface TimingTarget {
   beat: number;
   timeMs: number;
+  /** Expected frequencies of notes at this beat (first note of each string). */
+  expectedFrequencies: number[];
 }
 
 /**
@@ -17,18 +25,32 @@ export function buildTimingTargets(
   startTimeMs: number,
 ): TimingTarget[] {
   const msPerBeat = (60 / bpm) * 1000;
-  const uniqueBeats = [...new Set(notes.map((n) => n.beat))].sort(
-    (a, b) => a - b,
-  );
-  return uniqueBeats.map((beat) => ({
-    beat,
-    timeMs: startTimeMs + beat * msPerBeat,
-  }));
+  const notesByBeat = new Map<number, TabNote[]>();
+  for (const n of notes) {
+    const arr = notesByBeat.get(n.beat) ?? [];
+    arr.push(n);
+    notesByBeat.set(n.beat, arr);
+  }
+  return [...notesByBeat.keys()]
+    .sort((a, b) => a - b)
+    .map((beat) => {
+      const freqs = (notesByBeat.get(beat) ?? [])
+        .map(expectedFrequencyForNote)
+        .filter((f): f is number => f != null);
+      return {
+        beat,
+        timeMs: startTimeMs + beat * msPerBeat,
+        expectedFrequencies: freqs,
+      };
+    });
 }
 
 /**
  * Match an onset time to the nearest target beat.
  * Returns the TimingEvent or null if no target is within the hit window.
+ *
+ * Pitch fields are initialised to null here; the caller fills them in
+ * once a stable pitch sample is available after the onset.
  */
 export function evaluateOnset(
   onsetTimeMs: number,
@@ -60,6 +82,9 @@ export function evaluateOnset(
     onsetTimeMs,
     deltaMs: Math.round(minDelta),
     judgment,
+    expectedFrequency: closest.expectedFrequencies[0] ?? null,
+    detectedFrequency: null,
+    pitchCents: null,
   };
 }
 
@@ -81,21 +106,56 @@ export function generateMisses(
     }));
 }
 
+export interface TimingStats {
+  hitRate: number;
+  avgAbsDeltaMs: number;
+  /** Fraction of judged hits whose pitch was correct. 0 if no pitch data. */
+  pitchAccuracy: number;
+  /** Average absolute cents offset across pitch-judged hits. */
+  avgAbsCents: number;
+  /** Number of hits with pitch info (for stat confidence). */
+  pitchJudgedCount: number;
+}
+
 /**
  * Compute summary stats from timing events.
  */
-export function computeStats(events: TimingEvent[]): {
-  hitRate: number;
-  avgAbsDeltaMs: number;
-} {
-  if (events.length === 0) return { hitRate: 0, avgAbsDeltaMs: 0 };
+export function computeStats(events: TimingEvent[]): TimingStats {
+  if (events.length === 0)
+    return {
+      hitRate: 0,
+      avgAbsDeltaMs: 0,
+      pitchAccuracy: 0,
+      avgAbsCents: 0,
+      pitchJudgedCount: 0,
+    };
 
-  const hits = events.filter((e): e is import("../../types/practice").HitTimingEvent => e.judgment !== "miss");
+  const hits = events.filter(
+    (e): e is HitTimingEvent => e.judgment !== "miss",
+  );
   const hitRate = hits.length / events.length;
 
   const deltas = hits.map((e) => Math.abs(e.deltaMs));
   const avgAbsDeltaMs =
     deltas.length > 0 ? deltas.reduce((a, b) => a + b, 0) / deltas.length : 0;
 
-  return { hitRate, avgAbsDeltaMs: Math.round(avgAbsDeltaMs) };
+  const pitchJudged = hits.filter((e) => e.pitchCents != null);
+  const pitchCorrect = pitchJudged.filter(
+    (e) => e.judgment === "perfect",
+  ).length;
+  const pitchAccuracy =
+    pitchJudged.length > 0 ? pitchCorrect / pitchJudged.length : 0;
+  const absCents = pitchJudged.map((e) => Math.abs(e.pitchCents as number));
+  const avgAbsCents =
+    absCents.length > 0
+      ? absCents.reduce((a, b) => a + b, 0) / absCents.length
+      : 0;
+
+  return {
+    hitRate,
+    avgAbsDeltaMs: Math.round(avgAbsDeltaMs),
+    pitchAccuracy,
+    avgAbsCents: Math.round(avgAbsCents),
+    pitchJudgedCount: pitchJudged.length,
+  };
 }

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { tabPresets } from "../data/tabPresets";
 import { useCustomTabs } from "../hooks/useCustomTabs";
@@ -55,7 +55,13 @@ interface TabPracticeContentProps {
 
 function TabPracticeContent({ preset }: TabPracticeContentProps) {
   const audio = useAudioInput();
-  const practice = useTabPractice(preset, audio.engine);
+  const [pitchJudgeEnabled, setPitchJudgeEnabled] = useState(true);
+  const [toleranceCents, setToleranceCents] = useState(50);
+  const pitchJudge = useMemo(
+    () => ({ enabled: pitchJudgeEnabled, toleranceCents }),
+    [pitchJudgeEnabled, toleranceCents],
+  );
+  const practice = useTabPractice(preset, audio.engine, pitchJudge);
   const [startError, setStartError] = useState<string | null>(null);
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
@@ -186,6 +192,12 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
               onStop={practice.stopSession}
             />
             {autoBpmBlock}
+            <PitchJudgeToggle
+              enabled={pitchJudgeEnabled}
+              toleranceCents={toleranceCents}
+              onEnabledChange={setPitchJudgeEnabled}
+              onToleranceChange={setToleranceCents}
+            />
             {errorBlock}
           </div>
           <TimingFeedback
@@ -207,6 +219,12 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
             onStop={practice.stopSession}
           />
           {autoBpmBlock}
+          <PitchJudgeToggle
+            enabled={pitchJudgeEnabled}
+            toleranceCents={toleranceCents}
+            onEnabledChange={setPitchJudgeEnabled}
+            onToleranceChange={setToleranceCents}
+          />
           {errorBlock}
           <TimingFeedback
             lastEvent={practice.lastEvent}
@@ -216,6 +234,76 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
             loop={practice.loop}
           />
         </>
+      )}
+    </div>
+  );
+}
+
+interface PitchJudgeToggleProps {
+  enabled: boolean;
+  toleranceCents: number;
+  onEnabledChange: (v: boolean) => void;
+  onToleranceChange: (v: number) => void;
+}
+
+function PitchJudgeToggle({
+  enabled,
+  toleranceCents,
+  onEnabledChange,
+  onToleranceChange,
+}: PitchJudgeToggleProps) {
+  return (
+    <div
+      style={{
+        background: "var(--md-surface-container)",
+        borderRadius: 12,
+        padding: "12px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          font: "500 14px/1.4 Roboto, sans-serif",
+          color: "var(--md-on-surface)",
+          cursor: "pointer",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onEnabledChange(e.target.checked)}
+        />
+        音程の正確さを判定
+      </label>
+      {enabled && (
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            font: "400 13px/1.4 Roboto, sans-serif",
+            color: "var(--md-on-surface-variant)",
+          }}
+        >
+          <span style={{ minWidth: 80 }}>許容幅</span>
+          <input
+            type="range"
+            min={10}
+            max={100}
+            step={5}
+            value={toleranceCents}
+            onChange={(e) => onToleranceChange(Number(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ minWidth: 48, textAlign: "right" }}>
+            ±{toleranceCents}¢
+          </span>
+        </label>
       )}
     </div>
   );

--- a/src/types/practice.ts
+++ b/src/types/practice.ts
@@ -50,7 +50,13 @@ export interface TabPreset {
   notes: TabNote[];
 }
 
-export type TimingJudgment = "hit" | "early" | "late" | "miss";
+export type TimingJudgment =
+  | "hit" // timing-correct, pitch judgment disabled or unknown
+  | "perfect" // timing-correct + pitch-correct
+  | "timing-only" // timing-correct + pitch-incorrect
+  | "early"
+  | "late"
+  | "miss";
 
 interface TimingEventBase {
   targetBeat: number;
@@ -58,9 +64,14 @@ interface TimingEventBase {
 }
 
 export interface HitTimingEvent extends TimingEventBase {
-  judgment: "hit" | "early" | "late";
+  judgment: "hit" | "perfect" | "timing-only" | "early" | "late";
   onsetTimeMs: number;
   deltaMs: number; // positive = late, negative = early
+  // Pitch accuracy fields. `null` means pitch was not evaluated
+  // (pitch judgment disabled, or no clear pitch detected after onset).
+  expectedFrequency: number | null;
+  detectedFrequency: number | null;
+  pitchCents: number | null; // signed offset from expected in cents
 }
 
 export interface MissTimingEvent extends TimingEventBase {


### PR DESCRIPTION
Closes #46

## 概要
タブ譜練習にピッチ（音程）正確性の判定を統合。タイミングに加えて「実際に正しい音が鳴ったか」を評価できるようにした。

## 主な変更点

### 新モジュール `lib/practice/pitchEvaluator.ts`
- `BASS_OPEN_STRING_MIDI` — 4弦ベース標準チューニング（E1/A1/D2/G2）の MIDI 番号マップ
- `expectedFrequencyForNote(note)` — `TabNote` の弦番号・フレットから期待周波数を算出
- `judgePitch(detectedHz, expectedHz, toleranceCents)` — pitch-class folding（±600¢の範囲に畳み込み）することで、pitchy が低音でオクターブを落として返すケースも正解扱い
- テスト 21 件

### 判定モデルの拡張 (`types/practice.ts`)
`HitTimingEvent.judgment` に以下を追加:
- `perfect` — タイミング正解 + 音程正解
- `timing-only` — タイミング正解 + 音程不正解

既存の `hit` はピッチ判定 OFF または検出失敗時のフォールバック。`early` / `late` はピッチに関わらずそのまま。

### 判定フロー (`useTabPractice.ts`)
1. オンセット検出時、判定に `expectedFrequency: null` で仮登録
2. オンセットから **20–120ms** の窓で毎フレーム `detectPitch()` を呼び、最大 clarity のサンプルを保持（アタック直後はピッチ不安定なので最初の 20ms はスキップ）
3. 窓終了時に `finalizePitchSample` が発火し、同じイベントを `perfect` / `timing-only` に書き換え

ref ベースの差し替えで実装し、RAF ループの依存を増やさない（従来の "AudioContext が途中で再生成される" 罠を避けるため）。

### UI (`TabPracticePage.tsx`, `TimingFeedback.tsx`)
- 音程判定 ON/OFF チェックボックス + 許容幅スライダー（10–100¢, デフォルト ±50¢）
- 結果カードに **Pitch Accuracy**（%）と **Avg Cents** を追加
- リアルタイムフィードバックに検出セント偏差を表示
- 判定バッジ: PERFECT（青緑）/ TIMING（オレンジ）/ EARLY / LATE / MISS

## テスト
- 全 216 テスト通過（新規 +23）
- TypeScript / ESLint / production build ✅

## 備考
- スタッツの `pitchAccuracy` は「ピッチ判定されたヒットのうち perfect の割合」。OFF 時やピッチ未検出時は 0 で、`pitchJudgedCount > 0` のときのみカードを表示する
- ピッチ判定できない `early` / `late` はそもそも成功判定から外れるため、音程精度スタッツからは除外
