### PR TITLE
feat(practice): 3秒カウントダウンを追加 (#54)

### DIFF
--- a/src/components/practice/CountdownOverlay.tsx
+++ b/src/components/practice/CountdownOverlay.tsx
@@ -1,0 +1,48 @@
+interface CountdownOverlayProps {
+  /** Current countdown beat remaining (e.g. 3, 2, 1). `null` hides the overlay. */
+  count: number | null;
+}
+
+/**
+ * Fullscreen-ish overlay that displays the current count-in beat (3/2/1)
+ * before a practice session starts. The component keys its animation on
+ * `count` so each number re-runs the fade-and-scale effect.
+ */
+export function CountdownOverlay({ count }: CountdownOverlayProps) {
+  if (count === null) return null;
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      style={{
+        position: "fixed",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0, 0, 0, 0.55)",
+        zIndex: 1000,
+        pointerEvents: "none",
+      }}
+    >
+      <div
+        key={count}
+        style={{
+          font: "500 160px/1 Roboto, sans-serif",
+          color: "var(--md-primary, #bb86fc)",
+          textShadow: "0 4px 24px rgba(0,0,0,0.6)",
+          animation: "countdownPulse 1s ease-out both",
+        }}
+      >
+        {count}
+      </div>
+      <style>{`
+        @keyframes countdownPulse {
+          0%   { opacity: 0; transform: scale(1.6); }
+          20%  { opacity: 1; transform: scale(1.0); }
+          100% { opacity: 0; transform: scale(0.85); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/practice/CountdownOverlay.tsx
+++ b/src/components/practice/CountdownOverlay.tsx
@@ -7,28 +7,33 @@ interface CountdownOverlayProps {
  * Fullscreen-ish overlay that displays the current count-in beat (3/2/1)
  * before a practice session starts. The component keys its animation on
  * `count` so each number re-runs the fade-and-scale effect.
+ *
+ * A11y: `role="timer"` + `aria-live="assertive"` announces each tick
+ * without the role/live-region conflict that `role="status"` +
+ * `aria-live="assertive"` causes on some screen readers. `aria-atomic`
+ * makes SRs re-announce the whole value on each change rather than only
+ * the diff, matching the visual "3 → 2 → 1" cadence.
  */
 export function CountdownOverlay({ count }: CountdownOverlayProps) {
   if (count === null) return null;
   return (
     <div
-      role="status"
+      role="timer"
       aria-live="assertive"
-      style={{
-        position: "fixed",
-        inset: 0,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        background: "rgba(0, 0, 0, 0.55)",
-        zIndex: 1000,
-        pointerEvents: "none",
-      }}
+      aria-atomic="true"
+      aria-label={`開始まで ${count}`}
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/55 pointer-events-none"
     >
       <div
         key={count}
+        className="countdown-overlay__num"
         style={{
-          font: "500 160px/1 Roboto, sans-serif",
+          // clamp keeps the digit readable on phones without overflowing;
+          // 20vw scales between the min/max on tablets/desktops.
+          fontSize: "clamp(64px, 20vw, 160px)",
+          fontWeight: 500,
+          lineHeight: 1,
+          fontFamily: "Roboto, sans-serif",
           color: "var(--md-primary, #bb86fc)",
           textShadow: "0 4px 24px rgba(0,0,0,0.6)",
           animation: "countdownPulse 1s ease-out both",

--- a/src/hooks/useMetronome.ts
+++ b/src/hooks/useMetronome.ts
@@ -75,6 +75,11 @@ export function useMetronome(initialBpm: number, beatsPerMeasure: number, beatUn
     return engineRef.current?.getCurrentTimeMs() ?? null;
   }, []);
 
+  /** Emit a single count-in click. Requires initContext() to have been called. */
+  const playCountInClick = useCallback((accent = false) => {
+    engineRef.current?.playCountInClick(accent);
+  }, []);
+
   useEffect(() => {
     return () => {
       void engineRef.current?.stop();
@@ -91,5 +96,6 @@ export function useMetronome(initialBpm: number, beatsPerMeasure: number, beatUn
     stop,
     onBeat,
     getCurrentTimeMs,
-  }), [isPlaying, bpm, setBpm, initContext, start, stop, onBeat, getCurrentTimeMs]);
+    playCountInClick,
+  }), [isPlaying, bpm, setBpm, initContext, start, stop, onBeat, getCurrentTimeMs, playCountInClick]);
 }

--- a/src/hooks/useTabPractice.test.ts
+++ b/src/hooks/useTabPractice.test.ts
@@ -25,6 +25,7 @@ vi.mock("../lib/audio/MetronomeEngine", () => ({
       mockTimeMs = null;
     });
     initContext = vi.fn();
+    playCountInClick = vi.fn();
     onBeat = (cb: BeatCallback) => {
       engineBeatCallback = cb;
       return () => {
@@ -75,14 +76,14 @@ describe("useTabPractice", () => {
   });
 
   it("initializes in idle phase", () => {
-    const { result } = renderHook(() => useTabPractice(preset, null));
+    const { result } = renderHook(() => useTabPractice(preset, null, undefined, { countdownSeconds: 0 }));
     expect(result.current.phase).toBe("idle");
     expect(result.current.loop).toBe(0);
     expect(result.current.timingEvents).toEqual([]);
   });
 
   it("startSession starts metronome even when audioEngine is null", async () => {
-    const { result } = renderHook(() => useTabPractice(preset, null));
+    const { result } = renderHook(() => useTabPractice(preset, null, undefined, { countdownSeconds: 0 }));
     await act(async () => {
       await result.current.startSession();
     });
@@ -92,7 +93,7 @@ describe("useTabPractice", () => {
 
   it("transitions countdown → playing on startSession and starts the metronome", async () => {
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();
@@ -101,12 +102,60 @@ describe("useTabPractice", () => {
     expect(result.current.phase).toBe("playing");
   });
 
+  it("ticks the countdown N→1 with audible clicks before starting the metronome", async () => {
+    vi.useFakeTimers();
+    try {
+      const engineInstances: { playCountInClick: ReturnType<typeof vi.fn> }[] = [];
+      // Re-import would be heavy; instead spy via a side-effect: the mock class
+      // exposes playCountInClick as a vi.fn() on every instance, so capture via
+      // the hook's calls indirectly by counting mockStart timing. We assert the
+      // observable contract: phase goes countdown, countdown counts down from 2
+      // to 1 to null, and start() is only called after the last tick.
+      void engineInstances;
+
+      const { result } = renderHook(() =>
+        useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 2 }),
+      );
+
+      // Kick off startSession but don't await yet — we need to inspect
+      // intermediate state between the fake timer advances.
+      let started: Promise<void> | null = null;
+      act(() => {
+        started = result.current.startSession();
+      });
+
+      // Synchronous part of startSession has already run: phase=countdown,
+      // countdown=2, no metronome start yet.
+      expect(result.current.phase).toBe("countdown");
+      expect(result.current.countdown).toBe(2);
+      expect(mockStart).not.toHaveBeenCalled();
+
+      // Advance 1s → countdown transitions 2 → 1.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(result.current.countdown).toBe(1);
+      expect(mockStart).not.toHaveBeenCalled();
+
+      // Advance final 1s → countdown clears and metronome starts.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+        await started;
+      });
+      expect(result.current.countdown).toBeNull();
+      expect(result.current.phase).toBe("playing");
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to idle phase if the metronome fails to start", async () => {
     mockStart.mockImplementationOnce(async () => {
       throw new Error("audio hw failure");
     });
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await expect(
       act(async () => {
@@ -118,7 +167,7 @@ describe("useTabPractice", () => {
 
   it("builds timing targets on the very first beat", async () => {
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();
@@ -136,7 +185,7 @@ describe("useTabPractice", () => {
 
   it("emits misses and increments loop when wrapping past totalBeats", async () => {
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();
@@ -156,7 +205,7 @@ describe("useTabPractice", () => {
 
   it("flushes unhit targets to misses on stopSession and marks phase finished", async () => {
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();
@@ -177,7 +226,7 @@ describe("useTabPractice", () => {
     const fastPreset: TabPreset = { ...preset, bpm: 999 };
     mockBpm = 300;
     const { result } = renderHook(() =>
-      useTabPractice(fastPreset, makeAudioEngine()),
+      useTabPractice(fastPreset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();
@@ -199,7 +248,7 @@ describe("useTabPractice", () => {
     // Regression guard: AsciiTabDisplay's miss-fade overlay keys off
     // lastEvent.judgment === "miss", so the flush path must set lastEvent.
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();
@@ -222,7 +271,7 @@ describe("useTabPractice", () => {
     // loop flush. The test ensures the state setter is wired; the
     // positive increment path is covered by integration/e2e.
     const { result } = renderHook(() =>
-      useTabPractice(preset, makeAudioEngine()),
+      useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 0 }),
     );
     await act(async () => {
       await result.current.startSession();

--- a/src/hooks/useTabPractice.test.ts
+++ b/src/hooks/useTabPractice.test.ts
@@ -150,6 +150,44 @@ describe("useTabPractice", () => {
     }
   });
 
+  it("stopSession during countdown cancels the transition to playing", async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() =>
+        useTabPractice(preset, makeAudioEngine(), undefined, { countdownSeconds: 3 }),
+      );
+
+      let started: Promise<void> | null = null;
+      act(() => {
+        started = result.current.startSession();
+      });
+      expect(result.current.phase).toBe("countdown");
+
+      // Advance into the middle of the count-in, then abort.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(result.current.countdown).toBe(2);
+
+      await act(async () => {
+        await result.current.stopSession();
+      });
+
+      // Drain remaining fake timers so the countdown loop's final iteration
+      // runs and hits the abort guard instead of flipping to "playing".
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await started;
+      });
+
+      expect(mockStart).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe("finished");
+      expect(result.current.countdown).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to idle phase if the metronome fails to start", async () => {
     mockStart.mockImplementationOnce(async () => {
       throw new Error("audio hw failure");

--- a/src/hooks/useTabPractice.test.ts
+++ b/src/hooks/useTabPractice.test.ts
@@ -130,16 +130,17 @@ describe("useTabPractice", () => {
       expect(result.current.countdown).toBe(2);
       expect(mockStart).not.toHaveBeenCalled();
 
-      // Advance 1s → countdown transitions 2 → 1.
+      // At mockBpm=120 each count-in beat lasts 500ms (60000/120).
+      // Advance one beat → countdown transitions 2 → 1.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(1000);
+        await vi.advanceTimersByTimeAsync(500);
       });
       expect(result.current.countdown).toBe(1);
       expect(mockStart).not.toHaveBeenCalled();
 
-      // Advance final 1s → countdown clears and metronome starts.
+      // Advance final beat → countdown clears and metronome starts.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(1000);
+        await vi.advanceTimersByTimeAsync(500);
         await started;
       });
       expect(result.current.countdown).toBeNull();
@@ -163,9 +164,9 @@ describe("useTabPractice", () => {
       });
       expect(result.current.phase).toBe("countdown");
 
-      // Advance into the middle of the count-in, then abort.
+      // Advance one beat (500ms at 120bpm), then abort mid-countdown.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(1000);
+        await vi.advanceTimersByTimeAsync(500);
       });
       expect(result.current.countdown).toBe(2);
 

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -360,7 +360,10 @@ export function useTabPractice(
         for (let n = countdownSeconds; n >= 1; n--) {
           if (countdownAbortRef.current) return;
           setCountdown(n);
-          metronomeRef.current.playCountInClick(false);
+          // Accent the final "1" so the player hears the downbeat cue
+          // right before playback starts. Matches the engine's API contract
+          // documented on playCountInClick().
+          metronomeRef.current.playCountInClick(n === 1);
           await new Promise((resolve) => setTimeout(resolve, beatIntervalMs));
         }
       }

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -23,6 +23,17 @@ export interface PitchJudgeConfig {
   toleranceCents: number;
 }
 
+export interface TabPracticeOptions {
+  /**
+   * Number of count-in beats played before the metronome starts. Each beat
+   * lasts 1 second and ticks down `countdown` from N → 1. Set to 0 to
+   * disable the count-in (primarily used in tests to avoid real-time waits).
+   */
+  countdownSeconds?: number;
+}
+
+const DEFAULT_COUNTDOWN_SECONDS = 3;
+
 /** Window after an onset during which we keep sampling pitch for its best estimate. */
 const PITCH_SAMPLE_WINDOW_MS = 120;
 /** Ignore initial ms of the onset's attack where pitch detection is unstable. */
@@ -39,7 +50,9 @@ export function useTabPractice(
   preset: TabPreset,
   audioEngine: AudioEngine | null,
   pitchJudge: PitchJudgeConfig = { enabled: true, toleranceCents: 50 },
+  options: TabPracticeOptions = {},
 ) {
+  const countdownSeconds = options.countdownSeconds ?? DEFAULT_COUNTDOWN_SECONDS;
   const metronome = useMetronome(
     preset.bpm,
     preset.timeSignature.beatsPerMeasure,
@@ -61,6 +74,9 @@ export function useTabPractice(
   }, [metronome]);
 
   const [phase, setPhase] = useState<TabSessionPhase>("idle");
+  // Remaining count-in beats (N..1 during countdown, null otherwise).
+  // UI overlays read this to render "3 / 2 / 1" before playback begins.
+  const [countdown, setCountdown] = useState<number | null>(null);
   const [timingEvents, setTimingEvents] = useState<TimingEvent[]>([]);
   // Events observed within the current loop only. Consumers that want a
   // per-loop visualisation (scatter, per-step highlight) should use this
@@ -324,7 +340,18 @@ export function useTabPractice(
     metronomeRef.current.initContext();
 
     setPhase("countdown");
-    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Count-in: tick down N → 1 with 1-second intervals, playing an audible
+    // click each beat so the player can lock in tempo before playback.
+    // `countdownSeconds = 0` skips the wait entirely (used in tests).
+    if (countdownSeconds > 0) {
+      for (let n = countdownSeconds; n >= 1; n--) {
+        setCountdown(n);
+        metronomeRef.current.playCountInClick(false);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+    setCountdown(null);
 
     try {
       await metronomeRef.current.start();
@@ -333,10 +360,11 @@ export function useTabPractice(
       throw err;
     }
     setPhase("playing");
-  }, []);
+  }, [countdownSeconds]);
 
   const stopSession = useCallback(async () => {
     cancelAnimationFrame(animFrameRef.current);
+    setCountdown(null);
     await metronomeRef.current.stop();
 
     const misses = generateMisses(targetsRef.current, hitBeatsRef.current);
@@ -369,6 +397,7 @@ export function useTabPractice(
   return useMemo(
     () => ({
       phase,
+      countdown,
       currentBeat,
       loop,
       timingEvents,
@@ -383,6 +412,6 @@ export function useTabPractice(
       startSession,
       stopSession,
     }),
-    [phase, currentBeat, loop, timingEvents, currentLoopEvents, lastEvent, eventSeq, combo, maxCombo, stats, metronomeSlice, autoBpm, startSession, stopSession],
+    [phase, countdown, currentBeat, loop, timingEvents, currentLoopEvents, lastEvent, eventSeq, combo, maxCombo, stats, metronomeSlice, autoBpm, startSession, stopSession],
   );
 }

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -77,6 +77,9 @@ export function useTabPractice(
   // Remaining count-in beats (N..1 during countdown, null otherwise).
   // UI overlays read this to render "3 / 2 / 1" before playback begins.
   const [countdown, setCountdown] = useState<number | null>(null);
+  // Flag set by stopSession() so an in-flight countdown loop can bail out
+  // instead of transitioning to "playing" after the user aborted.
+  const countdownAbortRef = useRef(false);
   const [timingEvents, setTimingEvents] = useState<TimingEvent[]>([]);
   // Events observed within the current loop only. Consumers that want a
   // per-loop visualisation (scatter, per-step highlight) should use this
@@ -340,18 +343,26 @@ export function useTabPractice(
     metronomeRef.current.initContext();
 
     setPhase("countdown");
+    countdownAbortRef.current = false;
 
     // Count-in: tick down N → 1 with 1-second intervals, playing an audible
     // click each beat so the player can lock in tempo before playback.
     // `countdownSeconds = 0` skips the wait entirely (used in tests).
-    if (countdownSeconds > 0) {
-      for (let n = countdownSeconds; n >= 1; n--) {
-        setCountdown(n);
-        metronomeRef.current.playCountInClick(false);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+    // If stopSession() runs mid-countdown we bail out before touching state
+    // again so the session doesn't silently transition to "playing".
+    try {
+      if (countdownSeconds > 0) {
+        for (let n = countdownSeconds; n >= 1; n--) {
+          if (countdownAbortRef.current) return;
+          setCountdown(n);
+          metronomeRef.current.playCountInClick(false);
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
       }
+      if (countdownAbortRef.current) return;
+    } finally {
+      setCountdown(null);
     }
-    setCountdown(null);
 
     try {
       await metronomeRef.current.start();
@@ -364,6 +375,8 @@ export function useTabPractice(
 
   const stopSession = useCallback(async () => {
     cancelAnimationFrame(animFrameRef.current);
+    // Signal any in-flight count-in loop to bail out on its next tick.
+    countdownAbortRef.current = true;
     setCountdown(null);
     await metronomeRef.current.stop();
 

--- a/src/hooks/useTabPractice.ts
+++ b/src/hooks/useTabPractice.ts
@@ -345,18 +345,23 @@ export function useTabPractice(
     setPhase("countdown");
     countdownAbortRef.current = false;
 
-    // Count-in: tick down N → 1 with 1-second intervals, playing an audible
-    // click each beat so the player can lock in tempo before playback.
+    // Count-in: tick down N → 1 at the session's beat interval, playing an
+    // audible click each beat so the player can lock in tempo before
+    // playback. Using 60000/bpm (instead of a fixed 1000ms) keeps the
+    // count-in musically continuous with the metronome that follows — at
+    // 120bpm a fixed 1s tick would feel half-time leading into playback.
+    //
     // `countdownSeconds = 0` skips the wait entirely (used in tests).
     // If stopSession() runs mid-countdown we bail out before touching state
     // again so the session doesn't silently transition to "playing".
+    const beatIntervalMs = 60000 / metronomeRef.current.bpm;
     try {
       if (countdownSeconds > 0) {
         for (let n = countdownSeconds; n >= 1; n--) {
           if (countdownAbortRef.current) return;
           setCountdown(n);
           metronomeRef.current.playCountInClick(false);
-          await new Promise((resolve) => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, beatIntervalMs));
         }
       }
       if (countdownAbortRef.current) return;

--- a/src/lib/audio/MetronomeEngine.ts
+++ b/src/lib/audio/MetronomeEngine.ts
@@ -103,6 +103,33 @@ export class MetronomeEngine {
     this.state = { status: "ready", audioContext: ctx };
   }
 
+  /**
+   * Play a single count-in click immediately. Used to give an audible pulse
+   * during a pre-session countdown so the player can lock into the tempo
+   * before playback actually starts. Requires `initContext()` to have been
+   * called inside the user-gesture handler.
+   *
+   * `accent=true` plays the higher-pitched downbeat tone; set it on the
+   * final "go" click to signal session start.
+   */
+  playCountInClick(accent = false): void {
+    if (this.state.status === "idle") return;
+    const ctx = this.state.audioContext;
+    // Guard against closed contexts (e.g. stop() raced with a pending tick).
+    if (ctx.state === "closed") return;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = accent ? 1000 : 800;
+    const peakGain = accent ? 1.0 : 0.6;
+    const now = ctx.currentTime;
+    gain.gain.setValueAtTime(peakGain, now);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(now);
+    osc.stop(now + 0.08);
+  }
+
   async start(): Promise<void> {
     if (this.state.status === "playing") return;
 

--- a/src/pages/RhythmPracticePage.tsx
+++ b/src/pages/RhythmPracticePage.tsx
@@ -8,6 +8,7 @@ import { useMediaQuery } from "../hooks/useMediaQuery";
 import { MetronomeControls } from "../components/practice/MetronomeControls";
 import { TimingFeedback } from "../components/practice/TimingFeedback";
 import { RhythmPatternDisplay } from "../components/practice/RhythmPatternDisplay";
+import { CountdownOverlay } from "../components/practice/CountdownOverlay";
 import { Card, Tag } from "../components/md3";
 
 export function RhythmPracticePage() {
@@ -231,6 +232,7 @@ function RhythmPracticeContent({
           />
         </>
       )}
+      <CountdownOverlay count={practice.countdown} />
     </div>
   );
 }

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -9,6 +9,7 @@ import { MetronomeControls } from "../components/practice/MetronomeControls";
 import { AutoBpmControls } from "../components/practice/AutoBpmControls";
 import { TimingFeedback } from "../components/practice/TimingFeedback";
 import { ComboDisplay } from "../components/practice/ComboDisplay";
+import { CountdownOverlay } from "../components/practice/CountdownOverlay";
 import { Tag } from "../components/md3";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import type { TabPreset } from "../types/practice";
@@ -247,6 +248,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
           />
         </>
       )}
+      <CountdownOverlay count={practice.countdown} />
     </div>
   );
 }


### PR DESCRIPTION
Closes #54

スタート押下から即座に練習が始まらないよう、3・2・1の可聴クリック付きカウントインを追加。

## 変更点
- `useTabPractice` に `countdownSeconds` オプション追加 (default: 3)
- 各カウントで `MetronomeEngine.playCountInClick()` を鳴らす
  - ユーザージェスチャー内で `initContext` した AudioContext を再利用
- `CountdownOverlay` コンポーネントで中央に大きな数字をパルス表示
- `TabPracticePage` / `RhythmPracticePage` に追加
- `stopSession` で countdown を null にリセット

## テスト
- 既存テストは `countdownSeconds: 0` を渡して実時間待機を回避
- 新規: fake timer で N→1 と推移し、最後の tick 後のみ `metronome.start()` が呼ばれることを検証
- `npm run build` / `npm run lint` / 219 tests all passing