### PR TITLE
fix: practice waits for microphone readiness before starting

### DIFF
--- a/src/components/audio/AudioSetup.test.tsx
+++ b/src/components/audio/AudioSetup.test.tsx
@@ -65,6 +65,11 @@ describe("AudioSetup", () => {
       expect(onStart).toHaveBeenCalledOnce();
     });
 
+    it("起動中は Starting… を表示して Start ボタンを無効化する", () => {
+      render(<AudioSetup {...defaultProps} isStarting />);
+      expect(screen.getByRole("button", { name: "Starting…" })).toBeDisabled();
+    });
+
     it("「Stop」クリックで onStop() が呼ばれる", () => {
       const onStop = vi.fn();
       render(<AudioSetup {...defaultProps} isListening onStop={onStop} />);

--- a/src/components/audio/AudioSetup.tsx
+++ b/src/components/audio/AudioSetup.tsx
@@ -3,18 +3,20 @@ import { Card, FilledButton, OutlinedButton } from "../md3";
 
 interface AudioSetupProps {
   isListening: boolean;
+  isStarting?: boolean;
   isPermissionGranted: boolean;
   inputLevel: number;
   availableDevices: MediaDeviceInfo[];
   selectedDeviceId: string | null;
   error: string | null;
-  onStart: (deviceId?: string) => void;
+  onStart: (deviceId?: string) => void | Promise<void>;
   onStop: () => void;
   onSwitchDevice: (deviceId: string) => void;
 }
 
 export function AudioSetup({
   isListening,
+  isStarting = false,
   isPermissionGranted,
   inputLevel,
   availableDevices,
@@ -85,9 +87,10 @@ export function AudioSetup({
       <div style={{ display: "flex", gap: 12 }}>
         {!isListening ? (
           <FilledButton
-            label="Start Listening"
+            label={isStarting ? "Starting…" : "Start Listening"}
             icon="🎤"
             onClick={() => onStart()}
+            disabled={isStarting}
             style={{ flex: 1, justifyContent: "center" }}
           />
         ) : (

--- a/src/components/practice/MetronomeControls.test.tsx
+++ b/src/components/practice/MetronomeControls.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MetronomeControls } from "./MetronomeControls";
+
+const defaultProps = {
+  bpm: 120,
+  isPlaying: false,
+  phase: "idle" as const,
+  onBpmChange: vi.fn(),
+  onStart: vi.fn(),
+  onStop: vi.fn(),
+};
+
+describe("MetronomeControls", () => {
+  it("start pending 中はマイク起動メッセージを表示する", () => {
+    render(<MetronomeControls {...defaultProps} isStartPending />);
+    expect(screen.getByText("🎤 マイクを起動しています…")).toBeInTheDocument();
+  });
+
+  it("start pending 中は Start ボタンを無効化する", () => {
+    render(<MetronomeControls {...defaultProps} isStartPending />);
+    expect(screen.getByRole("button", { name: "Starting…" })).toBeDisabled();
+  });
+
+  it("countdown 中は従来の準備メッセージを表示する", () => {
+    render(<MetronomeControls {...defaultProps} phase="countdown" />);
+    expect(screen.getByText("♩ 準備して…")).toBeInTheDocument();
+  });
+});

--- a/src/components/practice/MetronomeControls.tsx
+++ b/src/components/practice/MetronomeControls.tsx
@@ -6,6 +6,7 @@ interface MetronomeControlsProps {
   bpm: number;
   isPlaying: boolean;
   phase: TabSessionPhase;
+  isStartPending?: boolean;
   onBpmChange: (bpm: number) => void;
   onStart: () => void;
   onStop: () => void;
@@ -14,6 +15,7 @@ interface MetronomeControlsProps {
 export function MetronomeControls({
   bpm,
   phase,
+  isStartPending = false,
   onBpmChange,
   onStart,
   onStop,
@@ -126,7 +128,7 @@ export function MetronomeControls({
         </span>
       </div>
 
-      {phase === "countdown" && (
+      {(phase === "countdown" || isStartPending) && (
         <div
           style={{
             textAlign: "center",
@@ -136,16 +138,17 @@ export function MetronomeControls({
             marginBottom: 12,
           }}
         >
-          ♩ 準備して…
+          {isStartPending ? "🎤 マイクを起動しています…" : "♩ 準備して…"}
         </div>
       )}
 
       <div style={{ display: "flex", gap: 12 }}>
         {phase === "idle" || phase === "finished" ? (
           <FilledButton
-            label={phase === "finished" ? "Restart" : "Start"}
+            label={isStartPending ? "Starting…" : phase === "finished" ? "Restart" : "Start"}
             icon={phase === "finished" ? "↺" : "▶"}
             onClick={onStart}
+            disabled={isStartPending}
             style={{ flex: 1, justifyContent: "center" }}
           />
         ) : (

--- a/src/hooks/useAudioInput.test.ts
+++ b/src/hooks/useAudioInput.test.ts
@@ -124,6 +124,65 @@ describe("useAudioInput", () => {
       });
     });
 
+    it("start() 途中に stop() されたら engine を最終的に起動しない", async () => {
+      let resolveStart: (() => void) | undefined;
+      mocks.engineStart.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useAudioInput());
+      let pending: Promise<void> | undefined;
+
+      await act(async () => {
+        pending = result.current.start();
+      });
+
+      await act(async () => {
+        await result.current.stop();
+      });
+
+      await act(async () => {
+        resolveStart?.();
+        await pending;
+      });
+
+      expect(result.current.isListening).toBe(false);
+      expect(result.current.engine).toBeNull();
+      // cancelled start で生成した engine は stop() されているはず
+      expect(mocks.engineStop).toHaveBeenCalled();
+    });
+
+    it("start() 途中に stop() されたらエラーを state に反映しない", async () => {
+      let rejectStart: ((err: Error) => void) | undefined;
+      mocks.engineStart.mockImplementation(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectStart = reject;
+          }),
+      );
+
+      const { result } = renderHook(() => useAudioInput());
+      let pending: Promise<void> | undefined;
+
+      await act(async () => {
+        pending = result.current.start();
+      });
+
+      await act(async () => {
+        await result.current.stop();
+      });
+
+      await act(async () => {
+        rejectStart?.(new Error("Permission denied"));
+        await pending?.catch(() => {});
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
     it("start() 後は isListening が true になる", async () => {
       const { result } = renderHook(() => useAudioInput());
       await act(async () => {

--- a/src/hooks/useAudioInput.test.ts
+++ b/src/hooks/useAudioInput.test.ts
@@ -72,6 +72,58 @@ describe("useAudioInput", () => {
   });
 
   describe("start()", () => {
+    it("start() 中は isStarting が true になる", async () => {
+      let resolveStart: (() => void) | undefined;
+      mocks.engineStart.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useAudioInput());
+      let pending: Promise<void> | undefined;
+
+      await act(async () => {
+        pending = result.current.start();
+      });
+
+      expect(result.current.isStarting).toBe(true);
+
+      await act(async () => {
+        resolveStart?.();
+        await pending;
+      });
+
+      expect(result.current.isStarting).toBe(false);
+    });
+
+    it("同時呼び出しでも AudioEngine.start() は 1 回だけ呼ばれる", async () => {
+      let resolveStart: (() => void) | undefined;
+      mocks.engineStart.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useAudioInput());
+      let first: Promise<void> | undefined;
+      let second: Promise<void> | undefined;
+
+      await act(async () => {
+        first = result.current.start();
+        second = result.current.start();
+      });
+
+      expect(mocks.engineStart).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveStart?.();
+        await Promise.all([first, second]);
+      });
+    });
+
     it("start() 後は isListening が true になる", async () => {
       const { result } = renderHook(() => useAudioInput());
       await act(async () => {
@@ -127,7 +179,7 @@ describe("useAudioInput", () => {
       mocks.engineStart.mockRejectedValue(new Error("Permission denied"));
       const { result } = renderHook(() => useAudioInput());
       await act(async () => {
-        await result.current.start();
+        await expect(result.current.start()).rejects.toThrow("Permission denied");
       });
       expect(result.current.error).toBe("Permission denied");
       expect(result.current.isListening).toBe(false);
@@ -137,7 +189,7 @@ describe("useAudioInput", () => {
       mocks.engineStart.mockRejectedValue("unexpected");
       const { result } = renderHook(() => useAudioInput());
       await act(async () => {
-        await result.current.start();
+        await expect(result.current.start()).rejects.toBe("unexpected");
       });
       expect(result.current.error).toBe("Failed to access microphone");
     });

--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -15,6 +15,8 @@ export function useAudioInput() {
   });
 
   const levelAnimationRef = useRef<number>(0);
+  const startPromiseRef = useRef<Promise<void> | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
   const [clarityThreshold, setClarityThresholdState] = useState(0.85);
 
   const updateLevel = useCallback(() => {
@@ -27,31 +29,50 @@ export function useAudioInput() {
 
   const start = useCallback(
     async (deviceId?: string) => {
-      try {
-        const newEngine = new AudioEngine();
-        await newEngine.start(deviceId);
-        engineRef.current = newEngine;
-        setEngine(newEngine);
-
-        const devices = await AudioEngine.enumerateDevices();
-
-        setState((prev) => ({
-          ...prev,
-          isPermissionGranted: true,
-          isListening: true,
-          selectedDeviceId: deviceId ?? null,
-          availableDevices: devices,
-          error: null,
-        }));
-
-        levelAnimationRef.current = requestAnimationFrame(updateLevel);
-      } catch (err) {
-        setState((prev) => ({
-          ...prev,
-          error:
-            err instanceof Error ? err.message : "Failed to access microphone",
-        }));
+      if (engineRef.current?.isActive) {
+        setState((prev) => ({ ...prev, error: null }));
+        return;
       }
+
+      if (startPromiseRef.current) {
+        return startPromiseRef.current;
+      }
+
+      const startPromise = (async () => {
+        setIsStarting(true);
+        try {
+          const newEngine = new AudioEngine();
+          await newEngine.start(deviceId);
+          engineRef.current = newEngine;
+          setEngine(newEngine);
+
+          const devices = await AudioEngine.enumerateDevices();
+
+          setState((prev) => ({
+            ...prev,
+            isPermissionGranted: true,
+            isListening: true,
+            selectedDeviceId: deviceId ?? null,
+            availableDevices: devices,
+            error: null,
+          }));
+
+          levelAnimationRef.current = requestAnimationFrame(updateLevel);
+        } catch (err) {
+          setState((prev) => ({
+            ...prev,
+            error:
+              err instanceof Error ? err.message : "Failed to access microphone",
+          }));
+          throw err;
+        } finally {
+          startPromiseRef.current = null;
+          setIsStarting(false);
+        }
+      })();
+
+      startPromiseRef.current = startPromise;
+      return startPromise;
     },
     [updateLevel],
   );
@@ -60,7 +81,9 @@ export function useAudioInput() {
     cancelAnimationFrame(levelAnimationRef.current);
     await engineRef.current?.stop();
     engineRef.current = null;
+    startPromiseRef.current = null;
     setEngine(null);
+    setIsStarting(false);
     setState((prev) => ({
       ...prev,
       isListening: false,
@@ -79,6 +102,7 @@ export function useAudioInput() {
   useEffect(() => {
     return () => {
       cancelAnimationFrame(levelAnimationRef.current);
+      startPromiseRef.current = null;
       engineRef.current?.stop();
       engineRef.current = null;
       setEngine(null);
@@ -92,13 +116,26 @@ export function useAudioInput() {
     }
   }, []);
 
-  return useMemo(() => ({
-    ...state,
-    engine,
-    clarityThreshold,
-    setClarityThreshold,
-    start,
-    stop,
-    switchDevice,
-  }), [state, engine, clarityThreshold, setClarityThreshold, start, stop, switchDevice]);
+  return useMemo(
+    () => ({
+      ...state,
+      engine,
+      isStarting,
+      clarityThreshold,
+      setClarityThreshold,
+      start,
+      stop,
+      switchDevice,
+    }),
+    [
+      state,
+      engine,
+      isStarting,
+      clarityThreshold,
+      setClarityThreshold,
+      start,
+      stop,
+      switchDevice,
+    ],
+  );
 }

--- a/src/hooks/useAudioInput.ts
+++ b/src/hooks/useAudioInput.ts
@@ -16,6 +16,7 @@ export function useAudioInput() {
 
   const levelAnimationRef = useRef<number>(0);
   const startPromiseRef = useRef<Promise<void> | null>(null);
+  const startTokenRef = useRef<{ cancelled: boolean } | null>(null);
   const [isStarting, setIsStarting] = useState(false);
   const [clarityThreshold, setClarityThresholdState] = useState(0.85);
 
@@ -38,15 +39,25 @@ export function useAudioInput() {
         return startPromiseRef.current;
       }
 
+      const token = { cancelled: false };
+      startTokenRef.current = token;
+
       const startPromise = (async () => {
         setIsStarting(true);
         try {
           const newEngine = new AudioEngine();
           await newEngine.start(deviceId);
+
+          // If stop() was called while awaiting mic permission, discard this engine.
+          if (token.cancelled) {
+            await newEngine.stop();
+            return;
+          }
           engineRef.current = newEngine;
           setEngine(newEngine);
 
           const devices = await AudioEngine.enumerateDevices();
+          if (token.cancelled) return;
 
           setState((prev) => ({
             ...prev,
@@ -59,14 +70,21 @@ export function useAudioInput() {
 
           levelAnimationRef.current = requestAnimationFrame(updateLevel);
         } catch (err) {
-          setState((prev) => ({
-            ...prev,
-            error:
-              err instanceof Error ? err.message : "Failed to access microphone",
-          }));
+          if (!token.cancelled) {
+            setState((prev) => ({
+              ...prev,
+              error:
+                err instanceof Error
+                  ? err.message
+                  : "Failed to access microphone",
+            }));
+          }
           throw err;
         } finally {
           startPromiseRef.current = null;
+          if (startTokenRef.current === token) {
+            startTokenRef.current = null;
+          }
           setIsStarting(false);
         }
       })();
@@ -79,6 +97,11 @@ export function useAudioInput() {
 
   const stop = useCallback(async () => {
     cancelAnimationFrame(levelAnimationRef.current);
+    // Cancel any in-flight start() so it won't resurrect engine state.
+    if (startTokenRef.current) {
+      startTokenRef.current.cancelled = true;
+      startTokenRef.current = null;
+    }
     await engineRef.current?.stop();
     engineRef.current = null;
     startPromiseRef.current = null;
@@ -102,6 +125,10 @@ export function useAudioInput() {
   useEffect(() => {
     return () => {
       cancelAnimationFrame(levelAnimationRef.current);
+      if (startTokenRef.current) {
+        startTokenRef.current.cancelled = true;
+        startTokenRef.current = null;
+      }
       startPromiseRef.current = null;
       engineRef.current?.stop();
       engineRef.current = null;

--- a/src/pages/RhythmPracticePage.tsx
+++ b/src/pages/RhythmPracticePage.tsx
@@ -53,20 +53,27 @@ function RhythmPracticeContent({
 }: ContentProps) {
   const practice = useTabPractice(preset, audio.engine);
   const [startError, setStartError] = useState<string | null>(null);
+  const [isStartPending, setIsStartPending] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const handleStart = async () => {
     setStartError(null);
-    if (!audio.isListening) audio.start().catch(() => {});
+    setIsStartPending(true);
+
     try {
+      if (!audio.isListening) {
+        await audio.start();
+      }
       await practice.startSession();
     } catch (err) {
       setStartError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsStartPending(false);
     }
   };
 
-  const displayedError = startError;
-  const micWarning = !startError && audio.error ? audio.error : null;
+  const displayedError = startError ?? audio.error;
+  const micWarning = null;
 
   const errorBlock = (
     <>
@@ -197,6 +204,7 @@ function RhythmPracticeContent({
               bpm={practice.metronome.bpm}
               isPlaying={practice.metronome.isPlaying}
               phase={practice.phase}
+              isStartPending={isStartPending || audio.isStarting}
               onBpmChange={practice.metronome.setBpm}
               onStart={handleStart}
               onStop={practice.stopSession}
@@ -217,6 +225,7 @@ function RhythmPracticeContent({
             bpm={practice.metronome.bpm}
             isPlaying={practice.metronome.isPlaying}
             phase={practice.phase}
+            isStartPending={isStartPending || audio.isStarting}
             onBpmChange={practice.metronome.setBpm}
             onStart={handleStart}
             onStop={practice.stopSession}

--- a/src/pages/RhythmPracticePage.tsx
+++ b/src/pages/RhythmPracticePage.tsx
@@ -73,7 +73,6 @@ function RhythmPracticeContent({
   };
 
   const displayedError = startError ?? audio.error;
-  const micWarning = null;
 
   const errorBlock = (
     <>
@@ -90,20 +89,6 @@ function RhythmPracticeContent({
           }}
         >
           {displayedError}
-        </div>
-      )}
-      {micWarning && (
-        <div
-          style={{
-            background: "#f9a8251a",
-            border: "1px solid #f9a82566",
-            color: "#f9a825",
-            borderRadius: 12,
-            padding: "12px 16px",
-            font: "400 13px/1.5 Roboto, sans-serif",
-          }}
-        >
-          🎤 マイクが利用できません（メトロノームは動作します）: {micWarning}
         </div>
       )}
     </>

--- a/src/pages/ScalePracticePage.tsx
+++ b/src/pages/ScalePracticePage.tsx
@@ -242,6 +242,7 @@ export function ScalePracticePage() {
 
       <AudioSetup
         isListening={audio.isListening}
+        isStarting={audio.isStarting}
         isPermissionGranted={audio.isPermissionGranted}
         inputLevel={audio.inputLevel}
         availableDevices={audio.availableDevices}

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -64,22 +64,27 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
   );
   const practice = useTabPractice(preset, audio.engine, pitchJudge);
   const [startError, setStartError] = useState<string | null>(null);
+  const [isStartPending, setIsStartPending] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const handleStart = async () => {
     setStartError(null);
-    if (!audio.isListening) {
-      audio.start().catch(() => {});
-    }
+    setIsStartPending(true);
+
     try {
+      if (!audio.isListening) {
+        await audio.start();
+      }
       await practice.startSession();
     } catch (err) {
       setStartError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsStartPending(false);
     }
   };
 
-  const displayedError = startError;
-  const micWarning = !startError && audio.error ? audio.error : null;
+  const displayedError = startError ?? audio.error;
+  const micWarning = null;
 
   const autoBpmBlock = (
     <AutoBpmControls
@@ -195,6 +200,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
               bpm={practice.metronome.bpm}
               isPlaying={practice.metronome.isPlaying}
               phase={practice.phase}
+              isStartPending={isStartPending || audio.isStarting}
               onBpmChange={practice.metronome.setBpm}
               onStart={handleStart}
               onStop={practice.stopSession}
@@ -224,6 +230,7 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
             bpm={practice.metronome.bpm}
             isPlaying={practice.metronome.isPlaying}
             phase={practice.phase}
+            isStartPending={isStartPending || audio.isStarting}
             onBpmChange={practice.metronome.setBpm}
             onStart={handleStart}
             onStop={practice.stopSession}

--- a/src/pages/TabPracticePage.tsx
+++ b/src/pages/TabPracticePage.tsx
@@ -84,7 +84,6 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
   };
 
   const displayedError = startError ?? audio.error;
-  const micWarning = null;
 
   const autoBpmBlock = (
     <AutoBpmControls
@@ -119,20 +118,6 @@ function TabPracticeContent({ preset }: TabPracticeContentProps) {
         </div>
       )}
 
-      {micWarning && (
-        <div
-          style={{
-            background: "#f9a8251a",
-            border: "1px solid #f9a82566",
-            color: "#f9a825",
-            borderRadius: 12,
-            padding: "12px 16px",
-            font: "400 13px/1.5 Roboto, sans-serif",
-          }}
-        >
-          🎤 マイクが利用できません（メトロノームは動作します）: {micWarning}
-        </div>
-      )}
     </>
   );
 

--- a/src/pages/TunerPage.tsx
+++ b/src/pages/TunerPage.tsx
@@ -41,6 +41,7 @@ export function TunerPage() {
           >
             <AudioSetup
               isListening={audio.isListening}
+              isStarting={audio.isStarting}
               isPermissionGranted={audio.isPermissionGranted}
               inputLevel={audio.inputLevel}
               availableDevices={audio.availableDevices}
@@ -61,6 +62,7 @@ export function TunerPage() {
           <PitchDisplay pitch={audio.isListening ? pitch : null} />
           <AudioSetup
             isListening={audio.isListening}
+            isStarting={audio.isStarting}
             isPermissionGranted={audio.isPermissionGranted}
             inputLevel={audio.inputLevel}
             availableDevices={audio.availableDevices}

--- a/src/pages/practiceStartFlow.test.tsx
+++ b/src/pages/practiceStartFlow.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { TabPracticePage } from "./TabPracticePage";
+import { RhythmPracticePage } from "./RhythmPracticePage";
+
+const audioState = {
+  isListening: false,
+  isStarting: false,
+  isPermissionGranted: false,
+  inputLevel: 0,
+  availableDevices: [],
+  selectedDeviceId: null,
+  error: null as string | null,
+  engine: null,
+  clarityThreshold: 0.85,
+  setClarityThreshold: vi.fn(),
+  start: vi.fn<() => Promise<void>>(),
+  stop: vi.fn(),
+  switchDevice: vi.fn(),
+};
+
+const practiceState = {
+  phase: "idle" as const,
+  currentBeat: -1,
+  loop: 0,
+  timingEvents: [],
+  currentLoopEvents: [],
+  lastEvent: null,
+  eventSeq: 0,
+  combo: 0,
+  maxCombo: 0,
+  stats: {
+    total: 0,
+    hit: 0,
+    perfect: 0,
+    timingOnly: 0,
+    miss: 0,
+    early: 0,
+    late: 0,
+    accuracy: 0,
+    pitchAccuracy: null,
+  },
+  metronome: {
+    bpm: 120,
+    isPlaying: false,
+    setBpm: vi.fn(),
+  },
+  autoBpm: {
+    config: { enabled: false, hitRateThreshold: 80, bpmIncrement: 5, maxBpm: 200 },
+    startBpm: 120,
+    levelUps: 0,
+    notification: null,
+    setEnabled: vi.fn(),
+    setHitRateThreshold: vi.fn(),
+    setBpmIncrement: vi.fn(),
+    setMaxBpm: vi.fn(),
+  },
+  startSession: vi.fn<() => Promise<void>>(),
+  stopSession: vi.fn(),
+};
+
+vi.mock("../hooks/useAudioInput", () => ({
+  useAudioInput: () => audioState,
+}));
+
+vi.mock("../hooks/useTabPractice", () => ({
+  useTabPractice: () => practiceState,
+}));
+
+vi.mock("../hooks/useCustomTabs", () => ({
+  useCustomTabs: () => ({ tabs: [] }),
+}));
+
+vi.mock("../hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+}));
+
+vi.mock("../components/practice/AsciiTabDisplay", () => ({
+  AsciiTabDisplay: () => <div>AsciiTabDisplay</div>,
+}));
+
+vi.mock("../components/practice/AutoBpmControls", () => ({
+  AutoBpmControls: () => <div>AutoBpmControls</div>,
+}));
+
+vi.mock("../components/practice/TimingFeedback", () => ({
+  TimingFeedback: () => <div>TimingFeedback</div>,
+}));
+
+vi.mock("../components/practice/ComboDisplay", () => ({
+  ComboDisplay: () => <div>ComboDisplay</div>,
+}));
+
+vi.mock("../components/practice/RhythmPatternDisplay", () => ({
+  RhythmPatternDisplay: () => <div>RhythmPatternDisplay</div>,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  audioState.isListening = false;
+  audioState.isStarting = false;
+  audioState.error = null;
+  audioState.start.mockResolvedValue(undefined);
+  practiceState.startSession.mockResolvedValue(undefined);
+});
+
+describe("practice start flow", () => {
+  it("tab practice waits for microphone startup before starting the session", async () => {
+    let resolveMic: (() => void) | undefined;
+    audioState.start.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMic = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/practice/tab/c-major-scale"]}>
+        <Routes>
+          <Route path="/practice/tab/:presetId" element={<TabPracticePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => expect(audioState.start).toHaveBeenCalledTimes(1));
+    expect(practiceState.startSession).not.toHaveBeenCalled();
+
+    resolveMic?.();
+
+    await waitFor(() => expect(practiceState.startSession).toHaveBeenCalledTimes(1));
+  });
+
+  it("rhythm practice waits for microphone startup before starting the session", async () => {
+    let resolveMic: (() => void) | undefined;
+    audioState.start.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMic = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/practice/rhythm"]}>
+        <Routes>
+          <Route path="/practice/rhythm" element={<RhythmPracticePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => expect(audioState.start).toHaveBeenCalledTimes(1));
+    expect(practiceState.startSession).not.toHaveBeenCalled();
+
+    resolveMic?.();
+
+    await waitFor(() => expect(practiceState.startSession).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows microphone startup errors instead of starting the session", async () => {
+    audioState.start.mockRejectedValue(new Error("Permission denied"));
+
+    render(
+      <MemoryRouter initialEntries={["/practice/tab/c-major-scale"]}>
+        <Routes>
+          <Route path="/practice/tab/:presetId" element={<TabPracticePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Permission denied");
+    });
+    expect(practiceState.startSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- wait for microphone startup before beginning tab/rhythm practice sessions
- surface a pending mic-start state in shared audio/practice controls
- add regression tests for the start flow and pending UI states

## Testing
- npm test
- npm run build
- npm run lint

Closes #56
