### PR TITLE
fix(#57): restrict beatUnit to quarter notes (validate aggressively)

### DIFF
--- a/src/lib/audio/MetronomeEngine.test.ts
+++ b/src/lib/audio/MetronomeEngine.test.ts
@@ -84,6 +84,15 @@ describe("MetronomeEngine", () => {
     expect(clamped.bpm).toBe(300);
   });
 
+  it("throws on unsupported beatUnit", () => {
+    expect(
+      () => new MetronomeEngine({ bpm: 120, beatsPerMeasure: 6, beatUnit: 8 }),
+    ).toThrow(RangeError);
+    expect(
+      () => new MetronomeEngine({ bpm: 120, beatsPerMeasure: 4, beatUnit: 2 }),
+    ).toThrow(RangeError);
+  });
+
   it("throws on invalid beatsPerMeasure", () => {
     expect(
       () => new MetronomeEngine({ bpm: 120, beatsPerMeasure: 0, beatUnit: 4 }),

--- a/src/lib/audio/MetronomeEngine.ts
+++ b/src/lib/audio/MetronomeEngine.ts
@@ -1,6 +1,16 @@
+import { assertSupportedBeatUnit } from "../practice/timeSignature";
+
 export interface MetronomeOptions {
   bpm: number;
   beatsPerMeasure: number;
+  /**
+   * Note value of a beat (denominator of the time signature).
+   *
+   * Currently only quarter-note beats (`4`) are supported: the scheduler
+   * treats tempo as quarter-note BPM via `60 / bpm` seconds per beat.
+   * Values other than 4 throw so mismatches between UI labels and actual
+   * playback can't slip in unnoticed. See `SUPPORTED_BEAT_UNITS`.
+   */
   beatUnit: number;
 }
 
@@ -35,6 +45,7 @@ export class MetronomeEngine {
 
   constructor(options: MetronomeOptions) {
     assertBeatsPerMeasure(options.beatsPerMeasure);
+    assertSupportedBeatUnit(options.beatUnit);
     this._bpm = MetronomeEngine.clampBpm(options.bpm);
     this._beatsPerMeasure = options.beatsPerMeasure;
     this._beatUnit = options.beatUnit;

--- a/src/lib/customTabs.test.ts
+++ b/src/lib/customTabs.test.ts
@@ -39,6 +39,18 @@ describe("customTabs persistence", () => {
     expect(loaded).toHaveLength(1);
     expect(loaded[0].name).toBe("ok");
   });
+
+  it("filters presets with unsupported beat units", () => {
+    const bad = {
+      ...createEmptyPreset({ name: "bad" }),
+      timeSignature: { beatsPerMeasure: 6, beatUnit: 8 },
+    };
+    const good = createEmptyPreset({ name: "good" });
+    localStorage.setItem(CUSTOM_TABS_STORAGE_KEY, JSON.stringify([bad, good]));
+    const loaded = loadCustomTabs();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].name).toBe("good");
+  });
 });
 
 describe("cloneAsCustom", () => {

--- a/src/lib/customTabs.ts
+++ b/src/lib/customTabs.ts
@@ -1,4 +1,5 @@
 import type { TabPreset, TabNote, TimeSignature } from "../types/practice";
+import { isSupportedTimeSignature } from "./practice/timeSignature";
 
 export const CUSTOM_TABS_STORAGE_KEY = "bass-practice.customTabs.v1";
 
@@ -31,6 +32,7 @@ function isValidPreset(value: unknown): value is TabPreset {
     typeof v.measures === "number" &&
     v.timeSignature != null &&
     typeof v.timeSignature === "object" &&
+    isSupportedTimeSignature(v.timeSignature as TimeSignature) &&
     Array.isArray(v.notes)
   );
 }

--- a/src/lib/practice/timeSignature.test.ts
+++ b/src/lib/practice/timeSignature.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  SUPPORTED_BEAT_UNITS,
+  isSupportedBeatUnit,
+  assertSupportedBeatUnit,
+  isSupportedTimeSignature,
+} from "./timeSignature";
+
+describe("timeSignature support", () => {
+  it("exposes 4 as the only supported beat unit", () => {
+    expect(SUPPORTED_BEAT_UNITS).toEqual([4]);
+  });
+
+  it("accepts quarter-note beat", () => {
+    expect(isSupportedBeatUnit(4)).toBe(true);
+  });
+
+  it("rejects 8/2/1/etc", () => {
+    expect(isSupportedBeatUnit(8)).toBe(false);
+    expect(isSupportedBeatUnit(2)).toBe(false);
+    expect(isSupportedBeatUnit(16)).toBe(false);
+  });
+
+  it("assertSupportedBeatUnit throws on unsupported", () => {
+    expect(() => assertSupportedBeatUnit(8)).toThrow(RangeError);
+    expect(() => assertSupportedBeatUnit(4)).not.toThrow();
+  });
+
+  it("validates full TimeSignature objects", () => {
+    expect(isSupportedTimeSignature({ beatsPerMeasure: 4, beatUnit: 4 })).toBe(true);
+    expect(isSupportedTimeSignature({ beatsPerMeasure: 3, beatUnit: 4 })).toBe(true);
+    expect(isSupportedTimeSignature({ beatsPerMeasure: 6, beatUnit: 8 })).toBe(false);
+    expect(isSupportedTimeSignature({ beatsPerMeasure: 0, beatUnit: 4 })).toBe(false);
+    expect(isSupportedTimeSignature({ beatsPerMeasure: 1.5, beatUnit: 4 })).toBe(false);
+  });
+});

--- a/src/lib/practice/timeSignature.ts
+++ b/src/lib/practice/timeSignature.ts
@@ -1,0 +1,36 @@
+import type { TimeSignature } from "../../types/practice";
+
+/**
+ * Beat units currently supported by the metronome / timing engine.
+ *
+ * The scheduling logic in `MetronomeEngine` and the target-time math in
+ * `timingEvaluator.buildTimingTargets` both assume the beat is a quarter
+ * note (i.e. `60 / bpm` seconds per beat, measuring tempo in quarter-note
+ * BPM). Until we add proper beat-unit scaling, only `x/4` meters behave
+ * consistently between the UI and the engine.
+ *
+ * Keep this list as a single source of truth so editor validation and
+ * preset validation agree on what's permitted.
+ */
+export const SUPPORTED_BEAT_UNITS = [4] as const;
+export type SupportedBeatUnit = (typeof SUPPORTED_BEAT_UNITS)[number];
+
+export function isSupportedBeatUnit(value: number): value is SupportedBeatUnit {
+  return (SUPPORTED_BEAT_UNITS as readonly number[]).includes(value);
+}
+
+export function assertSupportedBeatUnit(value: number): void {
+  if (!isSupportedBeatUnit(value)) {
+    throw new RangeError(
+      `beatUnit ${value} is not supported. Supported: ${SUPPORTED_BEAT_UNITS.join(", ")}`,
+    );
+  }
+}
+
+export function isSupportedTimeSignature(ts: TimeSignature): boolean {
+  return (
+    Number.isInteger(ts.beatsPerMeasure) &&
+    ts.beatsPerMeasure >= 1 &&
+    isSupportedBeatUnit(ts.beatUnit)
+  );
+}

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -137,11 +137,17 @@ export function EditorPage() {
           max={12}
           onChange={(v) => updateTimeSignature({ beatsPerMeasure: v })}
         />
+        {/*
+          Beat unit is fixed to 4 (quarter note) for now: the metronome and
+          timing evaluator both treat tempo as quarter-note BPM, so exposing
+          other denominators here would create a mismatch between the UI
+          label and actual playback. See `SUPPORTED_BEAT_UNITS`.
+        */}
         <LabeledNumber
           label="音符値"
           value={draft.timeSignature.beatUnit}
-          min={1}
-          max={16}
+          min={4}
+          max={4}
           onChange={(v) => updateTimeSignature({ beatUnit: v })}
         />
         <LabeledNumber


### PR DESCRIPTION
Closes #57

## 方針
Issueで提示された2案のうち **Option 2: サポートするbeatUnitを制限して厳しくバリデーションする** を採用。

理由:
- 既存のbuilt-inプリセットは全て `x/4`
- メトロノーム/timingEvaluator/count-in の全てを `beatUnit` 対応に書き換えるより、ドメインを実装に合わせて絞る方が確実で回帰リスクが低い

## 変更点
- `src/lib/practice/timeSignature.ts` を新設、`SUPPORTED_BEAT_UNITS = [4]` をsingle source of truthとして公開
- `MetronomeEngine` コンストラクタで `beatUnit` が未サポートなら `RangeError`
- `loadCustomTabs` が `isSupportedTimeSignature` でフィルタ → localStorageに残った旧6/8等のカスタムタブはロード時に除外
- `EditorPage` の「音符値」入力を `min=max=4` に固定。理由をコメントで明示

## 非対応
UI/型上は引き続き `beatUnit` を保持。将来 `x/8` などを本気で対応する場合はscheduler側を改修しつつ `SUPPORTED_BEAT_UNITS` を広げる方針。

## テスト
- `timeSignature.test.ts`: バリデーション関数
- `MetronomeEngine.test.ts`: 未サポートbeatUnitで throw
- `customTabs.test.ts`: 6/8プリセットがロード時に除外される

`npm run build` / `npx vitest run` (239 tests) / `npm run lint` all green.